### PR TITLE
Fix inline class name for team alternatives

### DIFF
--- a/core/admin/team_admin.py
+++ b/core/admin/team_admin.py
@@ -4,12 +4,12 @@ from unfold.admin import ModelAdmin, TabularInline
 from core.models.team import Team, TeamAlternativeName, TeamLogo
 
 
-class MyStackedInline(TabularInline):
+class TeamAlternativeNameTabularInline(TabularInline):
     model = TeamAlternativeName
     hide_title = True
 
 
-class MyTabularInline(TabularInline):
+class TeamLogoInline(TabularInline):
     model = TeamLogo
 
 
@@ -21,7 +21,7 @@ class TeamAdmin(ModelAdmin):
         "conference",
     )
     list_filter_sheet = False
-    inlines = [MyStackedInline, MyTabularInline]
+    inlines = [TeamAlternativeNameTabularInline, TeamLogoInline]
 
 
 @admin.register(TeamAlternativeName)


### PR DESCRIPTION
## Summary
- use tabular inline for team alternative names
- rename TeamLogo inline class
- update TeamAdmin inlines list

## Testing
- `python manage.py check`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_688b1a6938b08329a03c0c6f40362419