### PR TITLE
Add list_display columns to admin

### DIFF
--- a/core/admin/team_admin.py
+++ b/core/admin/team_admin.py
@@ -16,6 +16,12 @@ class TeamLogoInline(TabularInline):
 @admin.register(Team)
 class TeamAdmin(ModelAdmin):
     search_fields = ("school", "mascot")
+    list_display = (
+        "school",
+        "mascot",
+        "abbreviation",
+        "conference",
+    )
     list_filter = (
         "classification",
         "conference",
@@ -26,9 +32,15 @@ class TeamAdmin(ModelAdmin):
 
 @admin.register(TeamAlternativeName)
 class TeamAlternativeNameAdmin(ModelAdmin):
-    pass
+    list_display = (
+        "team",
+        "name",
+    )
 
 
 @admin.register(TeamLogo)
 class TeamLogoAdmin(ModelAdmin):
-    pass
+    list_display = (
+        "team",
+        "url",
+    )

--- a/core/admin/venue_admin.py
+++ b/core/admin/venue_admin.py
@@ -6,4 +6,8 @@ from core.models.venue import Venue
 
 @admin.register(Venue)
 class VenueAdmin(ModelAdmin):
-    pass
+    list_display = (
+        "name",
+        "city",
+        "state",
+    )


### PR DESCRIPTION
## Summary
- include more details for TeamAdmin
- show related columns for alt names and logos
- show venue address info in admin

## Testing
- `python manage.py check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b1c9660d4832992a18c0b2a09709f