### PR TITLE
Improve admin dashboard

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,6 +1,6 @@
 {% extends 'admin/base.html' %}
 
-{% load i18n %}
+{% load i18n unfold %}
 
 {% block breadcrumbs %}{% endblock %}
 
@@ -20,16 +20,22 @@
     {% url 'admin:core_team_changelist' as teams_url %}
     {% url 'admin:core_venue_changelist' as venues_url %}
 
-    <div class="flex flex-col lg:flex-row lg:gap-8">
-        <div class="grow">
-            <div class="grid gap-6 md:grid-cols-2 mb-8">
-                {% include "unfold/components/card.html" with href=teams_url title="Teams" icon="groups" children="Manage team information" %}
-                {% include "unfold/components/card.html" with href=venues_url title="Venues" icon="stadium" children="Manage venue details" %}
-            </div>
+    {% component "unfold/components/container.html" %}
+        <div class="flex flex-col gap-4">
+            {% component "unfold/components/navigation.html" with items=navigation %}
+            {% endcomponent %}
 
-            {% include "unfold/helpers/app_list_default.html" %}
+            {% component "unfold/components/navigation.html" with class="ml-auto" items=filters %}
+            {% endcomponent %}
         </div>
 
-        {% include "unfold/helpers/history.html" %}
-    </div>
+        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3 mb-8">
+            {% include "unfold/components/card.html" with href=teams_url title="Teams" icon="groups" children="Manage team information" class="lg:w-1/3" %}
+            {% include "unfold/components/card.html" with href=venues_url title="Venues" icon="stadium" children="Manage venue details" class="lg:w-1/3" %}
+        </div>
+
+        {% include "unfold/helpers/app_list_default.html" %}
+    {% endcomponent %}
+
+    {% include "unfold/helpers/history.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- enhance admin index page with Unfold cards linking to team and venue management
- show default app list and history sidebar
- ensure file ends with a newline

## Testing
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_688b68237a8c83298fe87fc2a580ed5e