### PR TITLE
Add color preview in team admin

### DIFF
--- a/core/admin/team_admin.py
+++ b/core/admin/team_admin.py
@@ -3,6 +3,8 @@ from django.templatetags.static import static
 from django.utils.html import format_html
 from unfold.admin import ModelAdmin, TabularInline
 
+from core.forms import TeamForm
+
 from core.models.team import Team, TeamAlternativeName, TeamLogo
 
 
@@ -33,6 +35,7 @@ class TeamLogoInline(TabularInline):
 
 @admin.register(Team)
 class TeamAdmin(ModelAdmin):
+    form = TeamForm
     search_fields = ("school", "mascot")
     list_display = (
         "logo_display",

--- a/core/forms.py
+++ b/core/forms.py
@@ -5,9 +5,9 @@ from core.models.team import Team
 
 
 class ColorPreviewWidget(forms.TextInput):
-    """TextInput widget that displays a color picker with preview box."""
+    """TextInput widget that displays a live color preview box."""
 
-    input_type = "color"
+    input_type = "text"
 
     def render(self, name, value, attrs=None, renderer=None):
         attrs = attrs or {}

--- a/core/forms.py
+++ b/core/forms.py
@@ -1,0 +1,35 @@
+from django import forms
+from django.utils.safestring import mark_safe
+
+from core.models.team import Team
+
+
+class ColorPreviewWidget(forms.TextInput):
+    """TextInput widget that displays a color picker with preview box."""
+
+    input_type = "color"
+
+    def render(self, name, value, attrs=None, renderer=None):
+        attrs = attrs or {}
+        attrs.setdefault("id", f"id_{name}")
+        preview_id = f"{attrs['id']}_preview"
+        attrs["data-color-preview"] = preview_id
+        html = super().render(name, value, attrs, renderer)
+        preview_html = (
+            f'<span id="{preview_id}" '
+            'class="inline-block w-5 h-5 ml-2 border align-middle"></span>'
+        )
+        return mark_safe(html + preview_html)
+
+
+class TeamForm(forms.ModelForm):
+    class Meta:
+        model = Team
+        fields = "__all__"
+        widgets = {
+            "color": ColorPreviewWidget(),
+            "alternate_color": ColorPreviewWidget(),
+        }
+
+    class Media:
+        js = ["js/color_preview.js"]

--- a/static/js/color_preview.js
+++ b/static/js/color_preview.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', function() {
+  document.querySelectorAll('input[data-color-preview]').forEach(function(input) {
+    const previewId = input.dataset.colorPreview;
+    const preview = document.getElementById(previewId);
+    function update() {
+      if (preview) {
+        preview.style.backgroundColor = input.value || 'transparent';
+      }
+    }
+    input.addEventListener('input', update);
+    update();
+  });
+});


### PR DESCRIPTION
## Summary
- add `ColorPreviewWidget` and `TeamForm`
- include JS helper for live color preview
- use the new form in `TeamAdmin`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688befb12124832992cda7a13207065e