### PR TITLE
Configure Unfold color palette

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -135,6 +135,43 @@ UNFOLD = {
     "SHOW_VIEW_ON_SITE": False,
     "SHOW_BACK_BUTTON": True,
     "BORDER_RADIUS": "0px",
+    # Use a bright orange palette inspired by classic college football colors
+    "COLORS": {
+        "base": {
+            "50": "249, 250, 251",
+            "100": "243, 244, 246",
+            "200": "229, 231, 235",
+            "300": "209, 213, 219",
+            "400": "156, 163, 175",
+            "500": "107, 114, 128",
+            "600": "75, 85, 99",
+            "700": "55, 65, 81",
+            "800": "31, 41, 55",
+            "900": "17, 24, 39",
+            "950": "3, 7, 18",
+        },
+        "primary": {
+            "50": "255, 247, 237",
+            "100": "255, 237, 213",
+            "200": "254, 215, 170",
+            "300": "253, 186, 116",
+            "400": "251, 146, 60",
+            "500": "249, 115, 22",
+            "600": "234, 88, 12",
+            "700": "194, 65, 12",
+            "800": "154, 52, 18",
+            "900": "124, 45, 18",
+            "950": "67, 20, 7",
+        },
+        "font": {
+            "subtle-light": "var(--color-base-500)",
+            "subtle-dark": "var(--color-base-400)",
+            "default-light": "var(--color-base-600)",
+            "default-dark": "var(--color-base-300)",
+            "important-light": "var(--color-base-900)",
+            "important-dark": "var(--color-base-100)",
+        },
+    },
     "SIDEBAR": {
         "navigation": [
             {


### PR DESCRIPTION
## Summary
- set bright orange color palette in Unfold settings

## Testing
- `python manage.py check`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688bf3d1224c832996a7256deaed7ab5