### PR TITLE
Improve admin field organization

### DIFF
--- a/core/admin/base_admin.py
+++ b/core/admin/base_admin.py
@@ -15,8 +15,43 @@ class UserAdmin(BaseUserAdmin, ModelAdmin):
     form = UserChangeForm
     add_form = UserCreationForm
     change_password_form = AdminPasswordChangeForm
+    fieldsets = tuple(
+        (
+            name,
+            {
+                **opts,
+                "classes": opts.get("classes", ()) + ("tab",),
+            },
+        )
+        for name, opts in BaseUserAdmin.fieldsets
+    )
+    add_fieldsets = tuple(
+        (
+            name,
+            {
+                **opts,
+                "classes": opts.get("classes", ()) + ("tab",),
+            },
+        )
+        for name, opts in BaseUserAdmin.add_fieldsets
+    )
 
 
 @admin.register(Group)
 class GroupAdmin(BaseGroupAdmin, ModelAdmin):
-    pass
+    fieldsets = (
+        (
+            "Group Info",
+            {
+                "fields": ("name",),
+                "classes": ("tab",),
+            },
+        ),
+        (
+            "Permissions",
+            {
+                "fields": ("permissions",),
+                "classes": ("tab",),
+            },
+        ),
+    )

--- a/core/admin/conference_admin.py
+++ b/core/admin/conference_admin.py
@@ -10,3 +10,15 @@ class ConferenceAdmin(ModelAdmin):
     list_filter = ("classification",)
     search_fields = ("name", "short_name", "abbreviation")
     list_filter_sheet = False
+    fieldsets = (
+        (
+            "General",
+            {
+                "fields": (
+                    ("name", "short_name"),
+                    ("abbreviation", "classification"),
+                ),
+                "classes": ("tab",),
+            },
+        ),
+    )

--- a/core/admin/team_admin.py
+++ b/core/admin/team_admin.py
@@ -88,15 +88,24 @@ class TeamAdmin(ModelAdmin):
     inlines = [VenueInline, TeamAlternativeNameTabularInline, TeamLogoInline]
     fieldsets = (
         (
-            None,
+            "General",
             {
                 "fields": (
                     ("school", "mascot"),
                     ("slug", "abbreviation"),
                     ("classification", "conference"),
+                ),
+                "classes": ("tab",),
+            },
+        ),
+        (
+            "Extras",
+            {
+                "fields": (
                     ("color", "alternate_color"),
                     "twitter",
                 ),
+                "classes": ("tab",),
             },
         ),
     )

--- a/core/admin/venue_admin.py
+++ b/core/admin/venue_admin.py
@@ -20,3 +20,29 @@ class VenueAdmin(ModelAdmin):
     )
     list_filter_sheet = False
     search_fields = ("name", "city", "state")
+    fieldsets = (
+        (
+            "General",
+            {
+                "fields": (
+                    "name",
+                    ("city", "state"),
+                    ("zip_code", "country_code"),
+                    ("capacity", "construction_year"),
+                ),
+                "classes": ("tab",),
+            },
+        ),
+        (
+            "Location",
+            {
+                "fields": (
+                    "timezone",
+                    ("latitude", "longitude"),
+                    "elevation",
+                    ("grass", "dome"),
+                ),
+                "classes": ("tab",),
+            },
+        ),
+    )


### PR DESCRIPTION
## Summary
- organize Conference admin with a tabbed General fieldset
- add tabs for Venue information and Location details
- split Team fields into General and Extras tabs
- group User and Group fields into tabs for better clarity

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688bf595f59c83299c44d5e4a5c4727c