### PR TITLE
Add CFBD game import to data import command

### DIFF
--- a/core/management/commands/import.py
+++ b/core/management/commands/import.py
@@ -1,11 +1,11 @@
 import os
+import time
 from datetime import date
 
 import cfbd
 from cfbd.rest import ApiException
 from django.core.management.base import BaseCommand, CommandError
 from dotenv import load_dotenv
-import time
 
 from core.models.conference import Conference
 from core.models.match import Match
@@ -14,7 +14,7 @@ from core.models.venue import Venue
 
 
 class Command(BaseCommand):
-    help = "Imports teams from CFBD API"
+    help = "Imports data from CFBD API"
 
     def add_arguments(self, parser):
         parser.add_argument(


### PR DESCRIPTION
## Summary
- extend import management command with `--start-year` and `--end-year` options
- import games via cfbd `get_games` API and persist to `Match`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890b1f8e4c88329858f25e012a12ce1