### PR TITLE
Add admin panel for match management

### DIFF
--- a/core/admin/__init__.py
+++ b/core/admin/__init__.py
@@ -2,6 +2,7 @@ from .base_admin import GroupAdmin, UserAdmin  # noqa: F401
 from .conference_admin import ConferenceAdmin  # noqa: F401
 from .team_admin import TeamAdmin  # noqa: F401
 from .venue_admin import VenueAdmin  # noqa: F401
+from .match_admin import MatchAdmin  # noqa: F401
 
 __all__ = [
     "UserAdmin",
@@ -9,4 +10,5 @@ __all__ = [
     "ConferenceAdmin",
     "TeamAdmin",
     "VenueAdmin",
+    "MatchAdmin",
 ]

--- a/core/admin/match_admin.py
+++ b/core/admin/match_admin.py
@@ -1,0 +1,39 @@
+from django.contrib import admin
+from unfold.admin import ModelAdmin
+
+from core.models.match import Match
+
+
+@admin.register(Match)
+class MatchAdmin(ModelAdmin):
+    list_display = (
+        "start_date",
+        "season",
+        "week",
+        "season_type",
+        "home_team",
+        "home_score",
+        "away_team",
+        "away_score",
+        "venue",
+        "completed",
+    )
+    list_filter = (
+        "season",
+        "season_type",
+        "completed",
+    )
+    search_fields = (
+        "home_team__school",
+        "home_team__mascot",
+        "away_team__school",
+        "away_team__mascot",
+    )
+    list_select_related = (
+        "home_team",
+        "away_team",
+        "venue",
+        "home_conference",
+        "away_conference",
+    )
+    list_filter_sheet = False


### PR DESCRIPTION
## Summary
- Add Django admin interface for Match model
- Wire up match admin in admin package

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890b5d599f88329bd7c58b7ffa08f0d