### PR TITLE
feat(admin): add team info dashboard

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -197,6 +197,16 @@ UNFOLD = {
                 ],
             },
             {
+                "title": "Dashboards",
+                "items": [
+                    {
+                        "title": "Team Info",
+                        "icon": "info",
+                        "link": lambda request: reverse("admin:team-info"),
+                    },
+                ],
+            },
+            {
                 "title": "User Management",
                 "separator": True,
                 "collapsible": True,

--- a/core/admin/__init__.py
+++ b/core/admin/__init__.py
@@ -2,6 +2,7 @@ from .base_admin import GroupAdmin, UserAdmin  # noqa: F401
 from .conference_admin import ConferenceAdmin  # noqa: F401
 from .team_admin import TeamAdmin  # noqa: F401
 from .venue_admin import VenueAdmin  # noqa: F401
+from .team_info_admin import team_info_page  # noqa: F401
 
 __all__ = [
     "UserAdmin",
@@ -9,4 +10,5 @@ __all__ = [
     "ConferenceAdmin",
     "TeamAdmin",
     "VenueAdmin",
+    "team_info_page",
 ]

--- a/core/admin/team_info_admin.py
+++ b/core/admin/team_info_admin.py
@@ -1,0 +1,110 @@
+from django.contrib import admin
+from django.db.models import Q
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404, render
+from django.urls import NoReverseMatch, path, reverse
+
+from core.models.match import Match
+from core.models.team import Team
+
+
+def team_info_page(request):
+    context = admin.site.each_context(request)
+    return render(request, "admin/team_info.html", context)
+
+
+def team_search(request):
+    query = request.GET.get("q", "")
+    teams = (
+        Team.objects.filter(
+            Q(school__icontains=query)
+            | Q(mascot__icontains=query)
+            | Q(alternative_names__name__icontains=query)
+        )
+        .distinct()
+        [:10]
+    )
+    results = [{"id": team.id, "name": str(team)} for team in teams]
+    return JsonResponse({"results": results})
+
+
+def team_detail(request, pk: int):
+    team = get_object_or_404(Team.objects.prefetch_related("logos", "location"), pk=pk)
+    logos = list(team.logos.values_list("url", flat=True))
+    matches_qs = (
+        Match.objects.filter(Q(home_team=team) | Q(away_team=team))
+        .select_related("home_team", "away_team", "venue")
+        [:5]
+    )
+    matches = []
+    for match in matches_qs:
+        if match.home_team_id == team.id:
+            opponent = match.away_team.school
+            team_score, opp_score = match.home_score, match.away_score
+        else:
+            opponent = match.home_team.school
+            team_score, opp_score = match.away_score, match.home_score
+        if (
+            match.completed
+            and team_score is not None
+            and opp_score is not None
+        ):
+            if team_score > opp_score:
+                result = "W"
+            elif team_score < opp_score:
+                result = "L"
+            else:
+                result = "T"
+        else:
+            result = ""
+        try:
+            url = reverse("admin:core_match_change", args=[match.pk])
+        except NoReverseMatch:
+            url = ""
+        matches.append(
+            {
+                "id": match.pk,
+                "opponent": opponent,
+                "date": match.start_date.strftime("%Y-%m-%d"),
+                "result": result,
+                "venue": match.venue.name if match.venue else "",
+                "url": url,
+            }
+        )
+    data = {
+        "id": team.pk,
+        "school": team.school,
+        "mascot": team.mascot or "",
+        "abbreviation": team.abbreviation or "",
+        "classification": team.get_classification_display() if team.classification else "",
+        "color": team.color,
+        "alternate_color": team.alternate_color,
+        "twitter": team.twitter or "",
+        "location": team.location.name if team.location else "",
+        "logos": logos,
+        "matches": matches,
+    }
+    return JsonResponse(data)
+
+
+def _get_admin_urls(urls):
+    def get_urls():
+        custom_urls = [
+            path("team-info/", admin.site.admin_view(team_info_page), name="team-info"),
+            path(
+                "team-info/search/",
+                admin.site.admin_view(team_search),
+                name="team-info-search",
+            ),
+            path(
+                "team-info/<int:pk>/",
+                admin.site.admin_view(team_detail),
+                name="team-info-detail",
+            ),
+        ]
+        return custom_urls + urls()
+
+    return get_urls
+
+
+admin.site.get_urls = _get_admin_urls(admin.site.get_urls)

--- a/templates/admin/team_completed_matches.html
+++ b/templates/admin/team_completed_matches.html
@@ -1,0 +1,15 @@
+{% for match in matches %}
+<a href="{{ match.url|default:'#' }}" class="block bg-white rounded border p-3 hover:bg-gray-50">
+    <div class="flex justify-between">
+        <span>{{ match.opponent }}</span>
+        <span>{{ match.date }}</span>
+    </div>
+    <div class="text-sm text-gray-600">
+        <span>{{ match.result }}</span>
+        <span class="ml-2">{{ match.venue }}</span>
+    </div>
+</a>
+{% endfor %}
+{% if next_page %}
+<div hx-get="{% url 'admin:team-info-results' team_id %}?page={{ next_page }}" hx-trigger="revealed" hx-swap="afterend"></div>
+{% endif %}

--- a/templates/admin/team_completed_matches.html
+++ b/templates/admin/team_completed_matches.html
@@ -1,23 +1,19 @@
 {% for match in matches %}
-<a href="{{ match.url|default:'#' }}" class="block bg-white rounded shadow p-4 hover:bg-gray-50">
-    <div class="flex items-center justify-between">
+<tr class="hover:bg-gray-50 cursor-pointer" {% if match.url %}onclick="window.location='{{ match.url }}'"{% endif %}>
+    <td class="px-4 py-2">{{ match.date }}</td>
+    <td class="px-4 py-2">
         <div class="flex items-center space-x-2">
-            {% if match.team_logo %}<img src="{{ match.team_logo }}" class="h-8 w-8 object-contain" />{% endif %}
-            <span class="font-semibold {{ match.result_class }}">{{ match.team_score }}</span>
-        </div>
-        <span class="font-bold {{ match.result_class }}">{{ match.result }}</span>
-        <div class="flex items-center space-x-2">
-            <span class="font-semibold">{{ match.opponent_score }}</span>
-            {% if match.opponent_logo %}<img src="{{ match.opponent_logo }}" class="h-8 w-8 object-contain" />{% endif %}
+            {% if match.opponent_logo %}<img src="{{ match.opponent_logo }}" class="h-6 w-6 object-contain" />{% endif %}
             <span>{{ match.opponent }}</span>
         </div>
-    </div>
-    <div class="mt-2 flex justify-between text-sm text-gray-600">
-        <span>{{ match.date }} &middot; {{ match.venue }}</span>
-        <span>Att: {{ match.attendance|default:"-" }}</span>
-    </div>
-</a>
+    </td>
+    <td class="px-4 py-2 font-semibold {{ match.result_class }}">{{ match.team_score }} - {{ match.opponent_score }}</td>
+    <td class="px-4 py-2">{{ match.venue }}</td>
+    <td class="px-4 py-2 text-right">{{ match.attendance|default:"-" }}</td>
+</tr>
 {% endfor %}
 {% if next_page %}
-<div hx-get="{% url 'admin:team-info-results' team_id %}?page={{ next_page }}" hx-trigger="revealed" hx-swap="afterend"></div>
+<tr hx-get="{% url 'admin:team-info-results' team_id %}?page={{ next_page }}" hx-trigger="revealed" hx-swap="afterend">
+    <td colspan="5"></td>
+</tr>
 {% endif %}

--- a/templates/admin/team_completed_matches.html
+++ b/templates/admin/team_completed_matches.html
@@ -1,12 +1,20 @@
 {% for match in matches %}
-<a href="{{ match.url|default:'#' }}" class="block bg-white rounded border p-3 hover:bg-gray-50">
-    <div class="flex justify-between">
-        <span>{{ match.opponent }}</span>
-        <span>{{ match.date }}</span>
+<a href="{{ match.url|default:'#' }}" class="block bg-white rounded shadow p-4 hover:bg-gray-50">
+    <div class="flex items-center justify-between">
+        <div class="flex items-center space-x-2">
+            {% if match.team_logo %}<img src="{{ match.team_logo }}" class="h-8 w-8 object-contain" />{% endif %}
+            <span class="font-semibold {{ match.result_class }}">{{ match.team_score }}</span>
+        </div>
+        <span class="font-bold {{ match.result_class }}">{{ match.result }}</span>
+        <div class="flex items-center space-x-2">
+            <span class="font-semibold">{{ match.opponent_score }}</span>
+            {% if match.opponent_logo %}<img src="{{ match.opponent_logo }}" class="h-8 w-8 object-contain" />{% endif %}
+            <span>{{ match.opponent }}</span>
+        </div>
     </div>
-    <div class="text-sm text-gray-600">
-        <span>{{ match.result }}</span>
-        <span class="ml-2">{{ match.venue }}</span>
+    <div class="mt-2 flex justify-between text-sm text-gray-600">
+        <span>{{ match.date }} &middot; {{ match.venue }}</span>
+        <span>Att: {{ match.attendance|default:"-" }}</span>
     </div>
 </a>
 {% endfor %}

--- a/templates/admin/team_info.html
+++ b/templates/admin/team_info.html
@@ -40,26 +40,34 @@
                 </div>
             </div>
 
-            <div x-show="team.upcoming_matches.length">
-                <h3 class="text-lg font-semibold mb-2">Upcoming Matches</h3>
-                <div class="space-y-2">
-                    <template x-for="match in team.upcoming_matches" :key="match.id">
-                        <a :href="match.url || '#'" class="block bg-white rounded border p-3 hover:bg-gray-50">
-                            <div class="flex justify-between">
-                                <span x-text="match.opponent"></span>
-                                <span x-text="match.date"></span>
-                            </div>
-                            <div class="text-sm text-gray-600">
-                                <span x-text="match.venue"></span>
-                            </div>
-                        </a>
-                    </template>
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <div>
+                    <h3 class="text-lg font-semibold mb-2">Latest Results</h3>
+                    <div id="completed-matches" class="space-y-2"></div>
                 </div>
-            </div>
-
-            <div>
-                <h3 class="text-lg font-semibold mb-2">Latest Results</h3>
-                <div id="completed-matches" class="space-y-2"></div>
+                <div x-show="team.upcoming_matches.length">
+                    <h3 class="text-lg font-semibold mb-2">Upcoming Matches</h3>
+                    <div class="space-y-2">
+                        <template x-for="match in team.upcoming_matches" :key="match.id">
+                            <a :href="match.url || '#'" class="block bg-white rounded shadow p-4 hover:bg-gray-50">
+                                <div class="flex items-center justify-between">
+                                    <div class="flex items-center space-x-2">
+                                        <img :src="match.home.logo" class="h-8 w-8 object-contain" />
+                                        <span x-text="match.home.name" :class="{'font-bold': match.is_home}"></span>
+                                    </div>
+                                    <div class="text-center text-sm text-gray-500">
+                                        <div x-text="match.date"></div>
+                                        <div x-text="match.venue"></div>
+                                    </div>
+                                    <div class="flex items-center space-x-2">
+                                        <span x-text="match.away.name" :class="{'font-bold': !match.is_home}"></span>
+                                        <img :src="match.away.logo" class="h-8 w-8 object-contain" />
+                                    </div>
+                                </div>
+                            </a>
+                        </template>
+                    </div>
+                </div>
             </div>
         </div>
     </template>

--- a/templates/admin/team_info.html
+++ b/templates/admin/team_info.html
@@ -1,0 +1,88 @@
+{% extends 'admin/base.html' %}
+{% load static %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block content %}
+<div class="p-6" x-data="teamInfo()">
+    <div class="max-w-xl mx-auto">
+        <input type="text" placeholder="Search teams" x-model="query" @input.debounce.300ms="searchTeams" class="w-full px-4 py-2 border rounded" />
+        <ul class="bg-white border rounded mt-1" x-show="results.length">
+            <template x-for="item in results" :key="item.id">
+                <li @click="selectTeam(item)" class="px-4 py-2 cursor-pointer hover:bg-gray-100" x-text="item.name"></li>
+            </template>
+        </ul>
+    </div>
+
+    <template x-if="team">
+        <div class="mt-6 space-y-6">
+            <div class="bg-white rounded shadow p-4">
+                <div class="flex flex-col md:flex-row md:items-center md:space-x-4">
+                    <template x-if="team.logos.length">
+                        <img :src="team.logos[0]" class="h-24 w-24 object-contain" />
+                    </template>
+                    <div>
+                        <h2 class="text-2xl font-bold" x-text="team.school"></h2>
+                        <p class="text-gray-600" x-text="team.mascot"></p>
+                    </div>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-2 mt-4 text-sm">
+                    <div><strong>Abbreviation:</strong> <span x-text="team.abbreviation"></span></div>
+                    <div><strong>Classification:</strong> <span x-text="team.classification"></span></div>
+                    <div><strong>Colors:</strong> <span x-text="team.color"></span>, <span x-text="team.alternate_color"></span></div>
+                    <div><strong>Twitter:</strong> <span x-text="team.twitter"></span></div>
+                    <div><strong>Location:</strong> <span x-text="team.location"></span></div>
+                </div>
+                <div class="flex space-x-2 mt-4" x-show="team.logos.length > 1">
+                    <template x-for="logo in team.logos.slice(1)" :key="logo">
+                        <img :src="logo" class="h-12 w-12 object-contain" />
+                    </template>
+                </div>
+            </div>
+
+            <div>
+                <h3 class="text-lg font-semibold mb-2">Recent Matches</h3>
+                <div class="space-y-2">
+                    <template x-for="match in team.matches" :key="match.id">
+                        <a :href="match.url || '#'" class="block bg-white rounded border p-3 hover:bg-gray-50">
+                            <div class="flex justify-between">
+                                <span x-text="match.opponent"></span>
+                                <span x-text="match.date"></span>
+                            </div>
+                            <div class="text-sm text-gray-600">
+                                <span x-text="match.result"></span>
+                                <span class="ml-2" x-text="match.venue"></span>
+                            </div>
+                        </a>
+                    </template>
+                </div>
+            </div>
+        </div>
+    </template>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+<script>
+function teamInfo() {
+    return {
+        query: '',
+        results: [],
+        team: null,
+        searchTeams() {
+            if (this.query.length < 2) {
+                this.results = [];
+                return;
+            }
+            fetch(`${window.location.pathname}search/?q=${encodeURIComponent(this.query)}`)
+                .then(res => res.json())
+                .then(data => { this.results = data.results; });
+        },
+        selectTeam(item) {
+            fetch(`${window.location.pathname}${item.id}/`)
+                .then(res => res.json())
+                .then(data => { this.team = data; this.query = data.school; this.results = []; });
+        }
+    }
+}
+</script>
+{% endblock %}

--- a/templates/admin/team_info.html
+++ b/templates/admin/team_info.html
@@ -43,30 +43,51 @@
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <div>
                     <h3 class="text-lg font-semibold mb-2">Latest Results</h3>
-                    <div id="completed-matches" class="space-y-2"></div>
+                    <table class="min-w-full divide-y divide-gray-200 text-sm">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left">Date</th>
+                                <th class="px-4 py-2 text-left">Opponent</th>
+                                <th class="px-4 py-2 text-left">Score</th>
+                                <th class="px-4 py-2 text-left">Venue</th>
+                                <th class="px-4 py-2 text-left">Attendance</th>
+                            </tr>
+                        </thead>
+                        <tbody id="completed-matches-body"></tbody>
+                    </table>
                 </div>
                 <div x-show="team.upcoming_matches.length">
                     <h3 class="text-lg font-semibold mb-2">Upcoming Matches</h3>
-                    <div class="space-y-2">
-                        <template x-for="match in team.upcoming_matches" :key="match.id">
-                            <a :href="match.url || '#'" class="block bg-white rounded shadow p-4 hover:bg-gray-50">
-                                <div class="flex items-center justify-between">
-                                    <div class="flex items-center space-x-2">
-                                        <img :src="match.home.logo" class="h-8 w-8 object-contain" />
-                                        <span x-text="match.home.name" :class="{'font-bold': match.is_home}"></span>
-                                    </div>
-                                    <div class="text-center text-sm text-gray-500">
-                                        <div x-text="match.date"></div>
-                                        <div x-text="match.venue"></div>
-                                    </div>
-                                    <div class="flex items-center space-x-2">
-                                        <span x-text="match.away.name" :class="{'font-bold': !match.is_home}"></span>
-                                        <img :src="match.away.logo" class="h-8 w-8 object-contain" />
-                                    </div>
-                                </div>
-                            </a>
-                        </template>
-                    </div>
+                    <table class="min-w-full divide-y divide-gray-200 text-sm">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left">Date</th>
+                                <th class="px-4 py-2 text-left">Home</th>
+                                <th class="px-4 py-2 text-left">Away</th>
+                                <th class="px-4 py-2 text-left">Venue</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <template x-for="match in team.upcoming_matches" :key="match.id">
+                                <tr class="hover:bg-gray-50">
+                                    <td class="px-4 py-2" x-text="match.date"></td>
+                                    <td class="px-4 py-2">
+                                        <div class="flex items-center space-x-2">
+                                            <img :src="match.home.logo" class="h-6 w-6 object-contain" />
+                                            <span x-text="match.home.name" :class="{'font-bold': match.is_home}"></span>
+                                        </div>
+                                    </td>
+                                    <td class="px-4 py-2">
+                                        <div class="flex items-center space-x-2">
+                                            <span x-text="match.away.name" :class="{'font-bold': !match.is_home}"></span>
+                    <img :src="match.away.logo" class="h-6 w-6 object-contain" />
+                                        </div>
+                                    </td>
+                                    <td class="px-4 py-2" x-text="match.venue"></td>
+                                </tr>
+                            </template>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
@@ -97,7 +118,7 @@ function teamInfo() {
                     this.team = data;
                     this.query = data.school;
                     this.results = [];
-                    htmx.ajax('GET', `${window.location.pathname}${item.id}/results/`, {target: '#completed-matches'});
+                    htmx.ajax('GET', `${window.location.pathname}${item.id}/results/`, {target: '#completed-matches-body'});
                 });
         }
     }

--- a/templates/admin/team_info.html
+++ b/templates/admin/team_info.html
@@ -40,27 +40,32 @@
                 </div>
             </div>
 
-            <div>
-                <h3 class="text-lg font-semibold mb-2">Recent Matches</h3>
+            <div x-show="team.upcoming_matches.length">
+                <h3 class="text-lg font-semibold mb-2">Upcoming Matches</h3>
                 <div class="space-y-2">
-                    <template x-for="match in team.matches" :key="match.id">
+                    <template x-for="match in team.upcoming_matches" :key="match.id">
                         <a :href="match.url || '#'" class="block bg-white rounded border p-3 hover:bg-gray-50">
                             <div class="flex justify-between">
                                 <span x-text="match.opponent"></span>
                                 <span x-text="match.date"></span>
                             </div>
                             <div class="text-sm text-gray-600">
-                                <span x-text="match.result"></span>
-                                <span class="ml-2" x-text="match.venue"></span>
+                                <span x-text="match.venue"></span>
                             </div>
                         </a>
                     </template>
                 </div>
             </div>
+
+            <div>
+                <h3 class="text-lg font-semibold mb-2">Latest Results</h3>
+                <div id="completed-matches" class="space-y-2"></div>
+            </div>
         </div>
     </template>
 </div>
 
+<script src="https://unpkg.com/htmx.org@1.9.10" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 <script>
 function teamInfo() {
@@ -80,7 +85,12 @@ function teamInfo() {
         selectTeam(item) {
             fetch(`${window.location.pathname}${item.id}/`)
                 .then(res => res.json())
-                .then(data => { this.team = data; this.query = data.school; this.results = []; });
+                .then(data => {
+                    this.team = data;
+                    this.query = data.school;
+                    this.results = [];
+                    htmx.ajax('GET', `${window.location.pathname}${item.id}/results/`, {target: '#completed-matches'});
+                });
         }
     }
 }


### PR DESCRIPTION
## Summary
- add custom admin dashboard page for team info
- expose fuzzy team search and match detail APIs
- build Tailwind/Unfold template for responsive team and match display

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6890b9c58d008329b5d412527cbef5e9