### PR TITLE
Prefetch team metadata and expose logo helpers

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/core/tests/test_team.py
+++ b/core/tests/test_team.py
@@ -1,0 +1,53 @@
+from typing import List
+
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from core.models.team import Team, TeamAlternativeName, TeamLogo
+
+
+class TeamManagerTests(TestCase):
+    def _create_team(self, school: str, logos: List[str], alt_names: List[str]):
+        team = Team.objects.create(
+            school=school,
+            color="#ffffff",
+            alternate_color="#000000",
+        )
+        for url in logos:
+            TeamLogo.objects.create(team=team, url=url)
+        for name in alt_names:
+            TeamAlternativeName.objects.create(team=team, name=name)
+        return team
+
+    def test_prefetch_related(self):
+        for idx in range(3):
+            self._create_team(
+                f"Tech {idx}", [f"url{idx}a", f"url{idx}b"], [f"Alt {idx}"]
+            )
+
+        with CaptureQueriesContext(connection) as ctx:
+            teams = list(Team.objects.filter(school__icontains="Tech"))
+            for team in teams:
+                team.logo_bright
+                team.logo_dark
+                list(team.alternative_names.all())
+
+        self.assertEqual(len(ctx.captured_queries), 3)
+
+    def test_logo_bright(self):
+        team = self._create_team("Bright Team", ["url1", "url2"], [])
+        self.assertEqual(team.logo_bright, "url1")
+
+    def test_logo_bright_none(self):
+        team = self._create_team("No Logo Team", [], [])
+        self.assertIsNone(team.logo_bright)
+
+    def test_logo_dark(self):
+        team = self._create_team("Dark Team", ["url1", "url2", "url3"], [])
+        self.assertEqual(team.logo_dark, "url2")
+
+    def test_logo_dark_none(self):
+        team = self._create_team("Single Logo Team", ["url1"], [])
+        self.assertIsNone(team.logo_dark)
+

--- a/core/views.py
+++ b/core/views.py
@@ -38,15 +38,10 @@ def index(request):
             GlickoRating.objects.filter(season=season, week=week)
             .order_by("-rating")
             .select_related("team")
-            .prefetch_related("team__logos")
             .filter(team__active=True)
         )[:25]
     else:
         ratings = GlickoRating.objects.none()
-
-    for rating in ratings:
-        logo = rating.team.logos.first()
-        rating.logo_url = logo.url if logo else None
 
     context = {
         "ratings": ratings,

--- a/templates/cotton/ranking_table.html
+++ b/templates/cotton/ranking_table.html
@@ -13,7 +13,7 @@
                 <td>{{ forloop.counter }}</td>
                 <td>
                     <a href="{{ rating.team.get_absolute_url }}" class="icon-link">
-                        <img src="{{ rating.logo_url }}"
+                        <img src="{{ rating.team.logo_bright }}"
                              alt="{{ rating.team.school }} logo"
                              style="height: 1em">
                         {{ rating.team.school }}


### PR DESCRIPTION
## Summary
- add `TeamQuerySet` and `TeamManager` that prefetch logos and alternative names
- expose `logo_bright` and `logo_dark` properties on `Team`
- document new features in `Team` model
- test manager prefetch behavior and logo helper properties

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6893e275e110832982310423a0e216da