### PR TITLE
Push filter params to URL on ranking view

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,7 @@
              hx-get="{% url 'index' %}"
              hx-trigger="load, refresh"
              hx-include="#season-select,#week-select"
+             hx-push-url="true"
              hx-target="#ranking-table">
             <c-ranking-table></c-ranking-table>
         </div>


### PR DESCRIPTION
## Summary
- push season and week selection parameters into browser URL for rankings

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6893e80f37c4832980d61147d6e9fec7