### PR TITLE
Add venue model tests

### DIFF
--- a/core/tests/test_venue_model.py
+++ b/core/tests/test_venue_model.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+
+from core.models.venue import Venue
+
+
+class VenueModelTests(TestCase):
+    def test_str_returns_name_and_location(self):
+        """``__str__`` returns '<name> (<city>, <state>)'."""
+        venue = Venue.objects.create(name="Memorial Stadium", city="Athens", state="GA")
+        self.assertEqual(str(venue), "Memorial Stadium (Athens, GA)")
+
+    def test_meta_options(self):
+        """Model meta options specify ordering and verbose names."""
+        self.assertEqual(Venue._meta.ordering, ["name"])
+        self.assertEqual(Venue._meta.verbose_name, "venue")
+        self.assertEqual(Venue._meta.verbose_name_plural, "venues")


### PR DESCRIPTION
## Summary
- add tests for Venue model __str__ and meta options

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6895f7e0d14083299cb04b7c7580e910