### PR TITLE
chore: streamline ruff excludes

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -2,32 +2,14 @@ line-length = 80
 indent-width = 4
 
 exclude = [
-    ".bzr",
-    ".direnv",
-    ".eggs",
     ".git",
-    ".git-rewrite",
-    ".hg",
-    ".ipynb_checkpoints",
     ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".pyenv",
     ".pytest_cache",
-    ".pytype",
     ".ruff_cache",
-    ".svn",
-    ".tox",
     ".venv",
-    ".vscode",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "site-packages",
     "venv",
+    "coverage/",
+    "core/migrations/",
 ]
 
 [lint]


### PR DESCRIPTION
## Summary
- streamline ruff exclude list to project-specific directories

## Testing
- `ruff check --config ruff.toml .`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689727cbe3bc83298bfceb25aeedf53c