### PR TITLE
Configure Ruff to use E and F checks

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -97,16 +97,28 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        "NAME": (
+            "django.contrib.auth.password_validation."
+            "UserAttributeSimilarityValidator"
+        ),
     },
     {
-        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "NAME": (
+            "django.contrib.auth.password_validation."
+            "MinimumLengthValidator"
+        ),
     },
     {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+        "NAME": (
+            "django.contrib.auth.password_validation."
+            "CommonPasswordValidator"
+        ),
     },
     {
-        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+        "NAME": (
+            "django.contrib.auth.password_validation."
+            "NumericPasswordValidator"
+        ),
     },
 ]
 
@@ -199,17 +211,23 @@ UNFOLD = {
                     {
                         "title": "Teams",
                         "icon": "groups",
-                        "link": lambda request: reverse("admin:core_team_changelist"),
+                        "link": lambda request: reverse(
+                            "admin:core_team_changelist"
+                        ),
                     },
                     {
                         "title": "Venues",
                         "icon": "stadium",
-                        "link": lambda request: reverse("admin:core_venue_changelist"),
+                        "link": lambda request: reverse(
+                            "admin:core_venue_changelist"
+                        ),
                     },
                     {
                         "title": "Matches",
                         "icon": "scoreboard",
-                        "link": lambda request: reverse("admin:core_match_changelist"),
+                        "link": lambda request: reverse(
+                            "admin:core_match_changelist"
+                        ),
                     },
                 ],
             },
@@ -221,12 +239,16 @@ UNFOLD = {
                     {
                         "title": "Users",
                         "icon": "person",
-                        "link": lambda request: reverse("admin:auth_user_changelist"),
+                        "link": lambda request: reverse(
+                            "admin:auth_user_changelist"
+                        ),
                     },
                     {
                         "title": "Groups",
                         "icon": "group_work",
-                        "link": lambda request: reverse("admin:auth_group_changelist"),
+                        "link": lambda request: reverse(
+                            "admin:auth_group_changelist"
+                        ),
                     },
                 ],
             },

--- a/core/admin/base_admin.py
+++ b/core/admin/base_admin.py
@@ -3,7 +3,11 @@ from django.contrib.auth.admin import GroupAdmin as BaseGroupAdmin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import Group, User
 from unfold.admin import ModelAdmin
-from unfold.forms import AdminPasswordChangeForm, UserChangeForm, UserCreationForm
+from unfold.forms import (
+    AdminPasswordChangeForm,
+    UserChangeForm,
+    UserCreationForm,
+)
 
 admin.site.unregister(User)
 admin.site.unregister(Group)

--- a/core/management/commands/glicko.py
+++ b/core/management/commands/glicko.py
@@ -98,7 +98,9 @@ class Command(BaseCommand):
             .distinct()
         )
         self.stdout.write(
-            f"Processing season {season}... {matches_qs.count()} matches found across {len(weeks)} weeks."
+            f"Processing season {season}... "
+            f"{matches_qs.count()} matches found across "
+            f"{len(weeks)} weeks."
         )
 
         season_active_teams: set[int] = set()
@@ -106,7 +108,8 @@ class Command(BaseCommand):
         for week in weeks:
             week_matches = matches_qs.filter(week=week).order_by("start_date")
             self.stdout.write(
-                f"  Processing week {week}... {week_matches.count()} matches found."
+                f"  Processing week {week}... "
+                f"{week_matches.count()} matches found."
             )
             self._process_week(
                 season,

--- a/core/management/commands/import.py
+++ b/core/management/commands/import.py
@@ -19,12 +19,17 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--conference", type=str, help="Optional conference abbreviation filter"
+            "--conference",
+            type=str,
+            help="Optional conference abbreviation filter",
         )
         parser.add_argument(
             "--year",
             type=int,
-            help="Optional year filter to get historical conference affiliations",
+            help=(
+                "Optional year filter to get historical "
+                "conference affiliations"
+            ),
         )
         parser.add_argument(
             "--start-year",
@@ -61,7 +66,9 @@ class Command(BaseCommand):
                     "timezone": venue.timezone,
                     "latitude": venue.latitude,
                     "longitude": venue.longitude,
-                    "elevation": float(venue.elevation) if venue.elevation else None,
+                    "elevation": float(venue.elevation)
+                    if venue.elevation
+                    else None,
                     "capacity": venue.capacity,
                     "construction_year": venue.construction_year,
                     "grass": venue.grass,
@@ -69,7 +76,8 @@ class Command(BaseCommand):
                 },
             )
             self.stdout.write(
-                f"Venue {venue.name} ({venue.city}, {venue.state}) imported/updated successfully."
+                f"Venue {venue.name} ({venue.city}, {venue.state}) "
+                "imported/updated successfully."
             )
 
     def import_conferences(self, api_instance):
@@ -92,19 +100,26 @@ class Command(BaseCommand):
                     "classification": conf.classification,
                 },
             )
-            self.stdout.write(f"Conference {conf.name} imported/updated successfully.")
+            self.stdout.write(
+                f"Conference {conf.name} imported/updated successfully."
+            )
 
     def import_teams(self, api_instance, *, conference=None, year=None):
         """Fetch team data and related records from CFBD.
 
         Steps:
-        1. Call :func:`TeamsApi.get_teams` with optional ``conference`` and ``year``.
-        2. Create or update :class:`Team` instances including venue and conference links.
-        3. Store associated :class:`TeamLogo` and :class:`TeamAlternativeName` records.
+        1. Call :func:`TeamsApi.get_teams` with optional ``conference`` and
+           ``year``.
+        2. Create or update :class:`Team` instances, including venue and
+           conference links.
+        3. Store associated :class:`TeamLogo` and
+           :class:`TeamAlternativeName` records.
         4. Output a status line for every processed team.
         """
 
-        teams_response = api_instance.get_teams(conference=conference, year=year)
+        teams_response = api_instance.get_teams(
+            conference=conference, year=year
+        )
 
         # Preload related objects so we do not hit the database for every team
         # iteration. ``in_bulk`` performs a single query returning a dictionary
@@ -115,7 +130,9 @@ class Command(BaseCommand):
         conferences_by_abbrev = {
             c.abbreviation: c for c in conferences.values() if c.abbreviation
         }
-        conferences_by_name = {c.name: c for c in conferences.values() if c.name}
+        conferences_by_name = {
+            c.name: c for c in conferences.values() if c.name
+        }
 
         # ``in_bulk`` without ``field_name`` defaults to the primary key, which
         # is already unique for venues. We can therefore use the returned
@@ -158,16 +175,18 @@ class Command(BaseCommand):
                     name=alt_name,
                 )
             self.stdout.write(
-                f"Team {team.school} ({team.abbreviation}) imported/updated successfully."
+                f"Team {team.school} ({team.abbreviation}) "
+                "imported/updated successfully."
             )
 
     def import_games(self, api_instance, *, start_year, end_year):
         """Fetch game data and store it using the :class:`Match` model.
 
         Steps:
-        1. Loop over the supplied year range and call :func:`GamesApi.get_games`.
-        2. ``update_or_create`` each :class:`Match` instance linking teams, venues,
-           and conferences where possible.
+        1. Loop over the supplied year range and call
+           :func:`GamesApi.get_games`.
+        2. ``update_or_create`` each :class:`Match` instance linking teams,
+           venues, and conferences where possible.
         3. Output a status line for every processed game.
         """
 
@@ -178,7 +197,9 @@ class Command(BaseCommand):
         conferences_by_abbrev = {
             c.abbreviation: c for c in conferences.values() if c.abbreviation
         }
-        conferences_by_name = {c.name: c for c in conferences.values() if c.name}
+        conferences_by_name = {
+            c.name: c for c in conferences.values() if c.name
+        }
 
         for season in range(start_year, end_year + 1):
             games_response = api_instance.get_games(
@@ -224,7 +245,8 @@ class Command(BaseCommand):
                     },
                 )
                 self.stdout.write(
-                    f"Match {game.home_team} vs {game.away_team} ({season}) imported/updated successfully."
+                    f"Match {game.home_team} vs {game.away_team} ({season}) "
+                    "imported/updated successfully."
                 )
 
     def handle(self, *args, **options):
@@ -246,13 +268,15 @@ class Command(BaseCommand):
                 step_start = time.perf_counter()
                 self.import_venues(venues_api_instance)
                 self.stdout.write(
-                    f"Venues import completed in {time.perf_counter() - step_start:.2f} seconds"
+                    f"Venues import completed in "
+                    f"{time.perf_counter() - step_start:.2f} seconds"
                 )
 
                 step_start = time.perf_counter()
                 self.import_conferences(conferences_api_instance)
                 self.stdout.write(
-                    f"Conferences import completed in {time.perf_counter() - step_start:.2f} seconds"
+                    f"Conferences import completed in "
+                    f"{time.perf_counter() - step_start:.2f} seconds"
                 )
 
                 step_start = time.perf_counter()
@@ -262,7 +286,8 @@ class Command(BaseCommand):
                     year=options.get("year"),
                 )
                 self.stdout.write(
-                    f"Teams import completed in {time.perf_counter() - step_start:.2f} seconds"
+                    f"Teams import completed in "
+                    f"{time.perf_counter() - step_start:.2f} seconds"
                 )
 
                 step_start = time.perf_counter()
@@ -272,7 +297,8 @@ class Command(BaseCommand):
                     end_year=options.get("end_year"),
                 )
                 self.stdout.write(
-                    f"Games import completed in {time.perf_counter() - step_start:.2f} seconds"
+                    f"Games import completed in "
+                    f"{time.perf_counter() - step_start:.2f} seconds"
                 )
             except ApiException as e:
                 self.stderr.write(f"Exception when calling CFBD API: {e}\n")

--- a/core/models/conference.py
+++ b/core/models/conference.py
@@ -27,7 +27,11 @@ class Conference(models.Model):
         return self.name
 
     def save(self, *args, **kwargs):
-        if not self.slug or self.slug == "" or slugify(self.name) not in self.slug:
+        if (
+            not self.slug
+            or self.slug == ""
+            or slugify(self.name) not in self.slug
+        ):
             base_slug = slugify(self.name)
             slug = base_slug
             counter = 1

--- a/core/models/match.py
+++ b/core/models/match.py
@@ -10,9 +10,10 @@ class Match(models.Model):
     """
     Represents a football match between two teams.
 
-    The 'completed_requires_scores' constraint ensures that if a match is marked as completed,
-    both home_score and away_score must be provided (not null). If the match is not completed,
-    scores may be null.
+    The 'completed_requires_scores' constraint ensures that if a match is
+    marked as completed, both ``home_score`` and ``away_score`` must be
+    provided (not null). If the match is not completed, scores may be
+    null.
     """
 
     season = models.PositiveIntegerField()
@@ -24,7 +25,11 @@ class Match(models.Model):
     start_date = models.DateTimeField()
     completed = models.BooleanField(default=False)
     venue = models.ForeignKey(
-        Venue, on_delete=models.SET_NULL, null=True, blank=True, related_name="matches"
+        Venue,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="matches",
     )
     neutral_site = models.BooleanField(default=False)
     attendance = models.PositiveIntegerField(blank=True, null=True)

--- a/core/models/team.py
+++ b/core/models/team.py
@@ -80,7 +80,11 @@ class Team(models.Model):
         return f"{self.school}{mascot}"
 
     def save(self, *args, **kwargs):
-        if not self.slug or self.slug == "" or slugify(self.school) not in self.slug:
+        if (
+            not self.slug
+            or self.slug == ""
+            or slugify(self.school) not in self.slug
+        ):
             base_slug = slugify(self.school)
             slug = base_slug
             counter = 1
@@ -128,11 +132,13 @@ class TeamAlternativeName(models.Model):
 
 
 class TeamLogo(models.Model):
-    """
-    Stores logo URLs for a team.
-    """
+    """Stores logo URLs for a team."""
 
-    team = models.ForeignKey(Team, on_delete=models.CASCADE, related_name="logos")
+    team = models.ForeignKey(
+        Team,
+        on_delete=models.CASCADE,
+        related_name="logos",
+    )
     url = models.URLField()
 
     def __str__(self):

--- a/core/urls.py
+++ b/core/urls.py
@@ -5,5 +5,9 @@ from .views.ranking_views import RankingListView
 
 urlpatterns = [
     path("", index_view, name="index"),
-    path("rankings/<str:classification>/", RankingListView.as_view(), name="rankings"),
+    path(
+        "rankings/<str:classification>/",
+        RankingListView.as_view(),
+        name="rankings",
+    ),
 ]

--- a/core/views/ranking_views.py
+++ b/core/views/ranking_views.py
@@ -21,7 +21,10 @@ class RankingListView(ListView):
 
     def get_classification(self):
         classification = self.kwargs.get("classification")
-        if classification and classification not in DivisionClassification.values:
+        if (
+            classification
+            and classification not in DivisionClassification.values
+        ):
             raise Http404
         return classification
 
@@ -51,9 +54,13 @@ class RankingListView(ListView):
         weeks = cache.get(weeks_key)
         if weeks is None:
             weeks_qs = (
-                queryset.filter(season=season) if season is not None else queryset
+                queryset.filter(season=season)
+                if season is not None
+                else queryset
             )
-            weeks = list(weeks_qs.order_by().values_list("week", flat=True).distinct())
+            weeks = list(
+                weeks_qs.order_by().values_list("week", flat=True).distinct()
+            )
             weeks.sort()
             cache.set(weeks_key, weeks, 3600)
         else:
@@ -61,7 +68,9 @@ class RankingListView(ListView):
         latest_week = weeks[-1] if weeks else None
         week = self.request.GET.get("week")
         week = (
-            int(week) if week and week.isdigit() and int(week) in weeks else latest_week
+            int(week)
+            if week and week.isdigit() and int(week) in weeks
+            else latest_week
         )
 
         return season, week, seasons, weeks
@@ -73,7 +82,12 @@ class RankingListView(ListView):
         if classification:
             qs = qs.filter(classification=classification)
 
-        self.season, self.week, self.seasons, self.weeks = self.get_season_and_week(qs)
+        (
+            self.season,
+            self.week,
+            self.seasons,
+            self.weeks,
+        ) = self.get_season_and_week(qs)
         # Filter by chosen season and week
         if self.season is not None:
             qs = qs.filter(season=self.season)
@@ -92,10 +106,14 @@ class RankingListView(ListView):
         weeks = getattr(self, "weeks", [])
 
         classification_label = (
-            DivisionClassification(classification).label if classification else None
+            DivisionClassification(classification).label
+            if classification
+            else None
         )
         title = (
-            f"{classification_label} Rankings" if classification_label else "Rankings"
+            f"{classification_label} Rankings"
+            if classification_label
+            else "Rankings"
         )
 
         context.update(

--- a/libs/glicko2.py
+++ b/libs/glicko2.py
@@ -82,7 +82,9 @@ class Player:
 
         """
         # Convert the rating and rating deviation values for internal use.
-        rating_list = [(x - DEFAULT_RATING) / GLICKO2_SCALER for x in rating_list]
+        rating_list = [
+            (x - DEFAULT_RATING) / GLICKO2_SCALER for x in rating_list
+        ]
         rd_list = [x / GLICKO2_SCALER for x in rd_list]
 
         v = self._v(rating_list, rd_list)
@@ -183,7 +185,10 @@ class Player:
         _E(int) -> float
 
         """
-        return 1 / (1 + math.exp(-1 * self._g(p2rd) * (self.__rating - p2rating)))
+        return 1 / (
+            1
+            + math.exp(-1 * self._g(p2rd) * (self.__rating - p2rating))
+        )
 
     def _g(self, rd):
         """The Glicko2 g(RD) function.

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [lint]
-select = []
+select = ["E", "F"]
 ignore = []
 fixable = ["ALL"]
 unfixable = []

--- a/tests/core/management/test_command_import.py
+++ b/tests/core/management/test_command_import.py
@@ -10,12 +10,12 @@ from cfbd.rest import ApiException
 from django.core.management.base import CommandError
 from django.test import TestCase
 from django.utils import timezone
-
-Command = import_module("core.management.commands.import").Command
 from core.models.conference import Conference
 from core.models.match import Match
 from core.models.team import Team
 from core.models.venue import Venue
+
+Command = import_module("core.management.commands.import").Command
 
 
 class ImportCommandTests(TestCase):
@@ -142,7 +142,7 @@ class ImportCommandTests(TestCase):
         self.assertEqual(venue.capacity, 56000)
 
     def test_import_conferences(self):
-        """``import_conferences`` creates and updates :class:`Conference` records."""
+        """``import_conferences`` creates and updates Conference records."""
         conferences = [self._sample_conference()]
         api = self._ns(get_conferences=lambda: conferences)
         self.command.import_conferences(api)
@@ -157,7 +157,7 @@ class ImportCommandTests(TestCase):
         self.assertEqual(conf.name, "ACC Updated")
 
     def test_import_teams(self):
-        """``import_teams`` creates teams and related records and updates them."""
+        """``import_teams`` creates and updates teams and related records."""
         self._import_prerequisites()
         teams = self._import_sample_teams()
 
@@ -178,7 +178,9 @@ class ImportCommandTests(TestCase):
 
         # Update team color and ensure related objects aren't duplicated
         teams[0].color = "#FF0000"
-        api_updated = self._ns(get_teams=lambda conference=None, year=None: [teams[0]])
+        api_updated = self._ns(
+            get_teams=lambda conference=None, year=None: [teams[0]]
+        )
         self.command.import_teams(api_updated)
         t1.refresh_from_db()
         self.assertEqual(t1.color, "#FF0000")
@@ -297,7 +299,9 @@ class ImportCommandTests(TestCase):
 
         self.command.import_venues.assert_called_once()
         self.command.import_conferences.assert_not_called()
-        self.assertIn("Exception when calling CFBD API", self.command.stderr.getvalue())
+        self.assertIn(
+            "Exception when calling CFBD API", self.command.stderr.getvalue()
+        )
         self.assertIn("Total import completed", self.command.stdout.getvalue())
 
     @patch("core.management.commands.import.cfbd.ApiClient")

--- a/tests/core/models/test_conference_model.py
+++ b/tests/core/models/test_conference_model.py
@@ -22,7 +22,9 @@ class ConferenceModelTests(TestCase):
 
     def test_save_preserves_valid_slug(self):
         """A slug containing the slugified name remains unchanged on save."""
-        conf = Conference.objects.create(name="Mountain West", slug="mountain-west-custom")
+        conf = Conference.objects.create(
+            name="Mountain West", slug="mountain-west-custom"
+        )
         original_slug = conf.slug
         conf.save()
         self.assertEqual(conf.slug, original_slug)

--- a/tests/core/models/test_team_model.py
+++ b/tests/core/models/test_team_model.py
@@ -79,7 +79,9 @@ class TeamManagerTests(TestCase):
         # Using the explicit manager method should keep query count constant
         with CaptureQueriesContext(connection) as ctx:
             teams = list(
-                Team.objects.with_related().filter(school__icontains="With Related")
+                Team.objects.with_related().filter(
+                    school__icontains="With Related"
+                )
             )
             for team in teams:
                 team.logo_bright
@@ -90,9 +92,7 @@ class TeamManagerTests(TestCase):
 
     def test_team_str_with_mascot(self):
         """``__str__`` should include the mascot when present."""
-        team = self._create_team(
-            "Georgia", [], [], mascot="Bulldogs"
-        )
+        team = self._create_team("Georgia", [], [], mascot="Bulldogs")
         self.assertEqual(str(team), "Georgia Bulldogs")
 
     def test_team_str_without_mascot(self):

--- a/tests/core/models/test_venue_model.py
+++ b/tests/core/models/test_venue_model.py
@@ -6,7 +6,9 @@ from core.models.venue import Venue
 class VenueModelTests(TestCase):
     def test_str_returns_name_and_location(self):
         """``__str__`` returns '<name> (<city>, <state>)'."""
-        venue = Venue.objects.create(name="Memorial Stadium", city="Athens", state="GA")
+        venue = Venue.objects.create(
+            name="Memorial Stadium", city="Athens", state="GA"
+        )
         self.assertEqual(str(venue), "Memorial Stadium (Athens, GA)")
 
     def test_meta_options(self):

--- a/tests/libs/test_glicko2.py
+++ b/tests/libs/test_glicko2.py
@@ -1,13 +1,12 @@
 import os
 import math
 import django
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
-django.setup()
-
 from django.test import TestCase
 from libs.glicko2 import Player
 from libs.constants import GLICKO2_SCALER
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
 
 
 class Glicko2Test(TestCase):
@@ -34,7 +33,9 @@ class Glicko2Test(TestCase):
         p._pre_rating_rd()
 
         # RD grows by volatility before being rescaled
-        expected_rd = math.sqrt((200 / GLICKO2_SCALER) ** 2 + 0.06**2) * GLICKO2_SCALER
+        expected_rd = (
+            math.sqrt((200 / GLICKO2_SCALER) ** 2 + 0.06**2) * GLICKO2_SCALER
+        )
         self.assertAlmostEqual(p.rd, expected_rd, places=12)
 
     def test_new_vol(self):
@@ -85,7 +86,9 @@ class Glicko2Test(TestCase):
 
         p = LoopPlayer(rating=1500, rd=200, vol=0.06, tau=0.5)
         v = p._v(self.scaled_ratings, self.scaled_rds)
-        new_vol = p._new_vol(self.scaled_ratings, self.scaled_rds, self.outcome_list, v)
+        new_vol = p._new_vol(
+            self.scaled_ratings, self.scaled_rds, self.outcome_list, v
+        )
 
         # Forcing the loop still converges to the known post-match volatility.
         self.assertAlmostEqual(new_vol, 0.05999342315486217, places=9)
@@ -109,5 +112,7 @@ class Glicko2Test(TestCase):
         p.did_not_compete()
 
         # Rating deviation grows identically to ``_pre_rating_rd``.
-        expected_rd = math.sqrt((50 / GLICKO2_SCALER) ** 2 + 0.06**2) * GLICKO2_SCALER
+        expected_rd = (
+            math.sqrt((50 / GLICKO2_SCALER) ** 2 + 0.06**2) * GLICKO2_SCALER
+        )
         self.assertAlmostEqual(p.rd, expected_rd, places=12)


### PR DESCRIPTION
## Summary
- scope Ruff linting to `E` and `F` rules at 80-character lines
- wrap long strings, docstrings, and function calls to satisfy E501

## Testing
- `ruff check --config ruff.toml .`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689729a0a87483298836f6a88d1764ab