### PR TITLE
Enable bugbear linting and fix tests

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [lint]
-select = ["E", "F"]
+select = ["E", "F", "B"]
 ignore = []
 fixable = ["ALL"]
 unfixable = []

--- a/tests/core/models/test_team_model.py
+++ b/tests/core/models/test_team_model.py
@@ -40,8 +40,8 @@ class TeamManagerTests(TestCase):
         with CaptureQueriesContext(connection) as ctx:
             teams = list(Team.objects.filter(school__icontains="Tech"))
             for team in teams:
-                team.logo_bright
-                team.logo_dark
+                _ = team.logo_bright
+                _ = team.logo_dark
                 list(team.alternative_names.all())
 
         # One query for teams, one for logos, and one for alt names
@@ -84,8 +84,8 @@ class TeamManagerTests(TestCase):
                 )
             )
             for team in teams:
-                team.logo_bright
-                team.logo_dark
+                _ = team.logo_bright
+                _ = team.logo_dark
                 list(team.alternative_names.all())
 
         self.assertEqual(len(ctx.captured_queries), 3)


### PR DESCRIPTION
## Summary
- enable flake8-bugbear in ruff config
- fix tests accessing team logos to avoid useless expression warnings

## Testing
- `ruff check --config ruff.toml .`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68973023e6008329867df3cc3b3de4a8