### PR TITLE
Enable import sorting and reorder imports

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [lint]
-select = ["E", "F", "B", "DJ"]
+select = ["E", "F", "B", "DJ", "I"]
 ignore = []
 fixable = ["ALL"]
 unfixable = []

--- a/tests/core/management/test_command_import.py
+++ b/tests/core/management/test_command_import.py
@@ -10,6 +10,7 @@ from cfbd.rest import ApiException
 from django.core.management.base import CommandError
 from django.test import TestCase
 from django.utils import timezone
+
 from core.models.conference import Conference
 from core.models.match import Match
 from core.models.team import Team

--- a/tests/core/models/test_conference_model.py
+++ b/tests/core/models/test_conference_model.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+
 from core.models.conference import Conference
 
 

--- a/tests/core/models/test_glicko_model.py
+++ b/tests/core/models/test_glicko_model.py
@@ -1,8 +1,8 @@
 from django.test import TestCase
 
+from core.models.enums import DivisionClassification
 from core.models.glicko import GlickoRating
 from core.models.team import Team
-from core.models.enums import DivisionClassification
 
 
 class GlickoRatingModelTests(TestCase):

--- a/tests/core/models/test_match_model.py
+++ b/tests/core/models/test_match_model.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timezone as dt_timezone
+from datetime import datetime
+from datetime import timezone as dt_timezone
 
 from django.db import IntegrityError, transaction
 from django.test import TestCase

--- a/tests/libs/test_glicko2.py
+++ b/tests/libs/test_glicko2.py
@@ -1,9 +1,11 @@
-import os
 import math
+import os
+
 import django
 from django.test import TestCase
-from libs.glicko2 import Player
+
 from libs.constants import GLICKO2_SCALER
+from libs.glicko2 import Player
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 django.setup()


### PR DESCRIPTION
## Summary
- enable Ruff's import sorting rule
- reorder imports across test modules to comply with the new rule

## Testing
- `pre-commit run --files ruff.toml tests/core/management/test_command_import.py tests/core/models/test_conference_model.py tests/core/models/test_glicko_model.py tests/core/models/test_match_model.py tests/libs/test_glicko2.py`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68978d5a63188329804892aa9764360b