### PR TITLE
ci: run workflow only for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 # Least-privilege token; enough to checkout and read repo contents
 permissions:


### PR DESCRIPTION
## Summary
- run CI only on pull_request events to avoid duplicate push runs

## Testing
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68978f77291483299f53316b30d5ba28