### PR TITLE
Enable Ruff checks for libs and fix warnings

### DIFF
--- a/libs/constants.py
+++ b/libs/constants.py
@@ -1,3 +1,5 @@
+"""Constants for the Glicko-2 rating system."""
+
 from core.models.enums import DivisionClassification
 
 # Glicko2 constants

--- a/ruff.toml
+++ b/ruff.toml
@@ -22,7 +22,6 @@ unfixable = []
 [lint.per-file-ignores]
 "config/**" = ["D"]
 "core/**" = ["ANN", "D"]
-"libs/**" = ["ANN", "D"]
 "tests/**" = ["ANN", "D"]
 
 


### PR DESCRIPTION
## Summary
- enforce Ruff docstring and annotation checks in `libs`
- document Glicko-2 constants and player rating implementation
- restore original algorithm comments for Glicko-2 routines

## Testing
- `ruff check`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68979faa6f3883299b4ca1c35f9d9a9d