### PR TITLE
chore: enforce core docstrings

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core application package."""

--- a/core/apps.py
+++ b/core/apps.py
@@ -1,6 +1,10 @@
+"""Application configuration for the core Django app."""
+
 from django.apps import AppConfig
 
 
 class CoreConfig(AppConfig):
+    """Configuration for the core app."""
+
     default_auto_field = "django.db.models.BigAutoField"
     name = "core"

--- a/core/management/__init__.py
+++ b/core/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for the core application."""

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,3 +1,5 @@
+"""URL routing configuration for the core app."""
+
 from django.urls import path
 
 from .views.index_view import index_view

--- a/ruff.toml
+++ b/ruff.toml
@@ -39,10 +39,6 @@ unfixable = []
 "core/views/**" = ["ANN", "D"]
 "core/models/**" = ["ANN", "D"]
 "core/admin/**" = ["ANN", "D"]
-"core/**" = [
-    "ANN",
-    "D",
-] # TODO: remove this line from the lint.per-file-ignores and fix all warnings
 "tests/**" = ["ANN", "D"]
 
 


### PR DESCRIPTION
## Summary
- remove blanket lint ignore for core modules
- document core packages and URLs to satisfy docstring rules

## Testing
- `ruff check .`
- `pre-commit run --files ruff.toml core/__init__.py core/apps.py core/urls.py core/management/__init__.py`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6897c76b74e48329bf8190cc8c11d61d