### PR TITLE
Ensure manage.py is linted by Ruff

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 
-def main():
+def main() -> None:
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     try:

--- a/ruff.toml
+++ b/ruff.toml
@@ -10,7 +10,6 @@ exclude = [
     "venv",
     "coverage/",
     "core/migrations/",
-    "manage.py",
 ]
 
 [lint]


### PR DESCRIPTION
## Summary
- include `manage.py` in Ruff linting
- annotate `main` in manage.py with return type

## Testing
- `ruff check manage.py`
- `./test.sh`
- `pre-commit run --files ruff.toml manage.py`


------
https://chatgpt.com/codex/tasks/task_e_6897c90c4dcc83298d8c522332f36571