### PR TITLE
Refine Ruff exclude configuration

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -2,14 +2,10 @@ line-length = 80
 indent-width = 4
 
 exclude = [
-    ".git",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".venv",
-    "venv",
     "coverage/",
-    "core/migrations/",
+    "**/migrations/**",
+    "static/",
+    "templates/",
 ]
 
 [lint]


### PR DESCRIPTION
## Summary
- simplify Ruff's exclude list by relying on defaults for common caches and virtual environments
- ignore `static/` and `templates/` directories
- replace specific `core/migrations/` exclusion with glob for all migrations

## Testing
- `ruff check .`
- `ruff check core/migrations --force-exclude`
- `./test.sh`
- `pre-commit run --files ruff.toml`


------
https://chatgpt.com/codex/tasks/task_e_6897cb5d4f2c8329bd630bf54e99a100