### PR TITLE
chore: enable docstring linting for models

### DIFF
--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -1,3 +1,5 @@
+"""Expose core data models for external use."""
+
 from .conference import Conference, DivisionClassification
 from .glicko import GlickoRating
 from .match import Match

--- a/core/models/conference.py
+++ b/core/models/conference.py
@@ -1,3 +1,5 @@
+"""Models for athletic conferences."""
+
 from django.db import models
 from django.utils.text import slugify
 
@@ -18,14 +20,18 @@ class Conference(models.Model):
     )
 
     class Meta:
+        """Metadata for Conference model."""
+
         ordering = ["name"]
         verbose_name = "conference"
         verbose_name_plural = "conferences"
 
     def __str__(self) -> str:
+        """Return the conference name."""
         return self.name
 
     def save(self, *args: object, **kwargs: object) -> None:
+        """Generate a unique slug before saving."""
         if (
             not self.slug
             or self.slug == ""

--- a/core/models/enums.py
+++ b/core/models/enums.py
@@ -1,3 +1,5 @@
+"""Enum definitions for core models."""
+
 from django.db import models
 
 

--- a/core/models/glicko.py
+++ b/core/models/glicko.py
@@ -1,3 +1,5 @@
+"""Glicko rating model for tracking team performance."""
+
 from django.db import models
 
 from libs.constants import DEFAULT_RATING, DEFAULT_RD, DEFAULT_VOLATILITY
@@ -46,6 +48,8 @@ class GlickoRating(models.Model):
     )
 
     class Meta:
+        """Metadata for GlickoRating model."""
+
         ordering = ["season", "week", "team_id"]
         verbose_name = "glicko rating"
         verbose_name_plural = "glicko ratings"
@@ -58,4 +62,5 @@ class GlickoRating(models.Model):
         indexes = [models.Index(fields=["team", "season", "week"])]
 
     def __str__(self) -> str:
+        """Return the rating for display."""
         return f"{self.season}-{self.week} {self.team}: {self.rating}"

--- a/core/models/match.py
+++ b/core/models/match.py
@@ -1,3 +1,5 @@
+"""Models for football matches between teams."""
+
 from django.db import models
 
 from core.models.conference import Conference
@@ -69,6 +71,8 @@ class Match(models.Model):
     away_score = models.PositiveIntegerField(blank=True, null=True)
 
     class Meta:
+        """Metadata for Match model."""
+
         constraints = [
             models.CheckConstraint(
                 check=(
@@ -85,4 +89,5 @@ class Match(models.Model):
         ordering = ["-start_date"]
 
     def __str__(self) -> str:
+        """Return a readable description of the match."""
         return f"{self.home_team} vs {self.away_team} on {self.start_date}"

--- a/core/models/team.py
+++ b/core/models/team.py
@@ -1,3 +1,5 @@
+"""Models for teams and related metadata."""
+
 from django.db import models
 from django.utils.text import slugify
 
@@ -7,7 +9,8 @@ from core.models.venue import Venue
 
 
 class TeamQuerySet(models.QuerySet):
-    """Custom ``QuerySet`` for :class:`Team`.
+    """
+    Custom ``QuerySet`` for :class:`Team`.
 
     Provides a helper to prefetch related ``logos`` and
     ``alternative_names`` to avoid N+1 queries.
@@ -24,14 +27,17 @@ class TeamManager(models.Manager):
     """Manager that always prefetches team metadata."""
 
     def get_queryset(self) -> "TeamQuerySet":
+        """Return a queryset with related data prefetched."""
         return TeamQuerySet(self.model, using=self._db).with_related()
 
     def with_related(self) -> "TeamQuerySet":
+        """Return a queryset with related data prefetched."""
         return self.get_queryset()
 
 
 class Team(models.Model):
-    """Represents a sports team and its related metadata.
+    """
+    Represents a sports team and its related metadata.
 
     The default manager automatically prefetches ``logos`` and
     ``alternative_names`` to keep database queries constant. The
@@ -70,15 +76,19 @@ class Team(models.Model):
     objects = TeamManager()
 
     class Meta:
+        """Metadata for Team model."""
+
         ordering = ["school"]
         verbose_name = "team"
         verbose_name_plural = "teams"
 
     def __str__(self) -> str:
+        """Return the team name and mascot."""
         mascot = f" {self.mascot}" if self.mascot else ""
         return f"{self.school}{mascot}"
 
     def save(self, *args: object, **kwargs: object) -> None:
+        """Generate a unique slug before saving."""
         if (
             not self.slug
             or self.slug == ""
@@ -107,9 +117,7 @@ class Team(models.Model):
 
 
 class TeamAlternativeName(models.Model):
-    """
-    Stores alternative names for a team.
-    """
+    """Store alternative names for a team."""
 
     team = models.ForeignKey(
         Team, on_delete=models.CASCADE, related_name="alternative_names"
@@ -117,6 +125,8 @@ class TeamAlternativeName(models.Model):
     name = models.CharField(max_length=200)
 
     class Meta:
+        """Metadata for TeamAlternativeName model."""
+
         constraints = [
             models.UniqueConstraint(
                 fields=["team", "name"],
@@ -127,6 +137,7 @@ class TeamAlternativeName(models.Model):
         verbose_name_plural = "team alternative names"
 
     def __str__(self) -> str:
+        """Return the alternative name with its team."""
         return f"{self.name} ({self.team.school})"
 
 
@@ -141,8 +152,11 @@ class TeamLogo(models.Model):
     url = models.URLField()
 
     class Meta:
+        """Metadata for TeamLogo model."""
+
         verbose_name = "team logo"
         verbose_name_plural = "team logos"
 
     def __str__(self) -> str:
+        """Return a readable representation of the logo."""
         return f"Logo for {self.team.school}: {self.url}"

--- a/core/models/venue.py
+++ b/core/models/venue.py
@@ -1,10 +1,10 @@
+"""Models for game venues."""
+
 from django.db import models
 
 
 class Venue(models.Model):
-    """
-    Represents a venue or stadium.
-    """
+    """Represents a venue or stadium."""
 
     name = models.CharField(max_length=200)
     city = models.CharField(max_length=100)
@@ -21,9 +21,12 @@ class Venue(models.Model):
     dome = models.BooleanField(null=True, blank=True)
 
     class Meta:
+        """Metadata for Venue model."""
+
         ordering = ["name"]
         verbose_name = "venue"
         verbose_name_plural = "venues"
 
     def __str__(self) -> str:
+        """Return a readable representation of the venue."""
         return f"{self.name} ({self.city}, {self.state})"

--- a/ruff.toml
+++ b/ruff.toml
@@ -28,7 +28,6 @@ unfixable = []
 "config/**" = ["D"]
 "core/management/commands/**" = ["ANN", "D"]
 "core/views/**" = ["ANN", "D"]
-"core/models/**" = ["D"]                     # TODO remove ignore rule from core/models
 "core/admin/**" = ["ANN", "D"]
 "tests/**" = ["ANN", "D"]
 


### PR DESCRIPTION
## Summary
- enforce docstring rules for `core/models` by removing legacy ignore
- document models and helper methods throughout the core models package

## Testing
- `pre-commit run --files ruff.toml core/models/__init__.py core/models/conference.py core/models/enums.py core/models/glicko.py core/models/match.py core/models/team.py core/models/venue.py`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6897d04ff0448329b8ec2b1816f19f19