### PR TITLE
chore: enforce lint for tests

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -24,10 +24,6 @@ ignore = ["D203", "D212"]
 fixable = ["ALL"]
 unfixable = []
 
-[lint.per-file-ignores] # TODO: Remove
-"tests/**" = ["ANN", "D"] # TODO: Remove
-
-
 [format]
 quote-style = "double"
 indent-style = "space"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the project."""

--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the core application."""

--- a/tests/core/admin/__init__.py
+++ b/tests/core/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Django admin customizations."""

--- a/tests/core/admin/test_team_admin.py
+++ b/tests/core/admin/test_team_admin.py
@@ -1,3 +1,5 @@
+"""Tests for ``TeamAdmin`` and related inlines."""
+
 from django.contrib import admin
 from django.test import TestCase
 
@@ -7,7 +9,10 @@ from core.models.venue import Venue
 
 
 class TeamLogoInlineTests(TestCase):
-    def setUp(self):
+    """Tests for :class:`TeamLogoInline`."""
+
+    def setUp(self) -> None:
+        """Create a team and inline instance for logo tests."""
         self.team = Team.objects.create(
             school="Logo Team",
             color="#ffffff",
@@ -15,13 +20,13 @@ class TeamLogoInlineTests(TestCase):
         )
         self.inline = TeamLogoInline(Team, admin.site)
 
-    def test_preview_with_url(self):
+    def test_preview_with_url(self) -> None:
         """``preview`` renders an image tag when a logo URL exists."""
         logo = TeamLogo.objects.create(team=self.team, url="http://logo")
         html = self.inline.preview(logo)
         self.assertIn('<img src="http://logo" class="h-16" />', html)
 
-    def test_preview_without_url_uses_placeholder(self):
+    def test_preview_without_url_uses_placeholder(self) -> None:
         """``preview`` falls back to a placeholder when no URL is set."""
         logo = TeamLogo(team=self.team)
         html = self.inline.preview(logo)
@@ -29,10 +34,13 @@ class TeamLogoInlineTests(TestCase):
 
 
 class VenueInlineTests(TestCase):
-    def setUp(self):
+    """Tests for :class:`VenueInline`."""
+
+    def setUp(self) -> None:
+        """Create the inline used for venue tests."""
         self.inline = VenueInline(Team, admin.site)
 
-    def test_get_form_queryset_with_location(self):
+    def test_get_form_queryset_with_location(self) -> None:
         """``get_form_queryset`` returns the team's current location."""
         venue = Venue.objects.create(name="Stadium", city="City", state="ST")
         team = Team.objects.create(
@@ -44,12 +52,12 @@ class VenueInlineTests(TestCase):
         qs = self.inline.get_form_queryset(team)
         self.assertEqual(list(qs), [venue])
 
-    def test_get_form_queryset_without_location(self):
+    def test_get_form_queryset_without_location(self) -> None:
         """``get_form_queryset`` is empty when the team has no location."""
         qs = self.inline.get_form_queryset(None)
         self.assertEqual(list(qs), [])
 
-    def test_save_new_instance_sets_parent_location(self):
+    def test_save_new_instance_sets_parent_location(self) -> None:
         """``save_new_instance`` assigns the venue to the parent team."""
         team = Team.objects.create(
             school="Parent",
@@ -62,10 +70,13 @@ class VenueInlineTests(TestCase):
 
 
 class TeamAdminTests(TestCase):
-    def setUp(self):
+    """Tests for :class:`TeamAdmin`."""
+
+    def setUp(self) -> None:
+        """Create the admin instance used in tests."""
         self.admin = TeamAdmin(Team, admin.site)
 
-    def test_logo_display_returns_html(self):
+    def test_logo_display_returns_html(self) -> None:
         """``logo_display`` renders the team's logo when available."""
         team = Team.objects.create(
             school="Display Team",
@@ -76,7 +87,7 @@ class TeamAdminTests(TestCase):
         html = self.admin.logo_display(team)
         self.assertIn('<img src="http://display" class="h-8" />', html)
 
-    def test_logo_display_without_logo(self):
+    def test_logo_display_without_logo(self) -> None:
         """``logo_display`` is ``None`` when the team has no logos."""
         team = Team.objects.create(
             school="No Logo",

--- a/tests/core/management/__init__.py
+++ b/tests/core/management/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for custom Django management commands."""

--- a/tests/core/models/__init__.py
+++ b/tests/core/models/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for core data models."""

--- a/tests/core/models/test_conference_model.py
+++ b/tests/core/models/test_conference_model.py
@@ -1,27 +1,31 @@
+"""Tests for the :class:`Conference` model."""
+
 from django.test import TestCase
 
 from core.models.conference import Conference
 
 
 class ConferenceModelTests(TestCase):
-    def test_str_returns_name(self):
+    """Behavior tests for ``Conference``."""
+
+    def test_str_returns_name(self) -> None:
         """``__str__`` returns the conference name."""
         conf = Conference.objects.create(name="Big Ten")
         self.assertEqual(str(conf), "Big Ten")
 
-    def test_save_generates_unique_slugs(self):
+    def test_save_generates_unique_slugs(self) -> None:
         """Saving conferences with the same name generates unique slugs."""
         c1 = Conference.objects.create(name="Big Ten")
         c2 = Conference.objects.create(name="Big Ten")
         self.assertEqual(c1.slug, "big-ten")
         self.assertEqual(c2.slug, "big-ten-1")
 
-    def test_save_overwrites_invalid_slug(self):
+    def test_save_overwrites_invalid_slug(self) -> None:
         """A provided slug that doesn't contain the name is replaced."""
         conf = Conference.objects.create(name="Mid-American", slug="invalid")
         self.assertEqual(conf.slug, "mid-american")
 
-    def test_save_preserves_valid_slug(self):
+    def test_save_preserves_valid_slug(self) -> None:
         """A slug containing the slugified name remains unchanged on save."""
         conf = Conference.objects.create(
             name="Mountain West", slug="mountain-west-custom"

--- a/tests/core/models/test_glicko_model.py
+++ b/tests/core/models/test_glicko_model.py
@@ -1,3 +1,5 @@
+"""Tests for the :class:`GlickoRating` model."""
+
 from django.test import TestCase
 
 from core.models.enums import DivisionClassification
@@ -6,6 +8,8 @@ from core.models.team import Team
 
 
 class GlickoRatingModelTests(TestCase):
+    """Behavior tests for :class:`GlickoRating`."""
+
     def _create_team(self, school: str = "Test Team") -> Team:
         """Create a minimal team for use in Glicko rating tests."""
         return Team.objects.create(
@@ -14,7 +18,7 @@ class GlickoRatingModelTests(TestCase):
             alternate_color="#000000",
         )
 
-    def test_str_includes_identifiers(self):
+    def test_str_includes_identifiers(self) -> None:
         """``__str__`` should include season-week, team and rating."""
         team = self._create_team("String Team")
         rating = GlickoRating.objects.create(
@@ -28,7 +32,7 @@ class GlickoRatingModelTests(TestCase):
         )
         self.assertEqual(str(rating), "2024-3 String Team: 1600")
 
-    def test_rating_change_generated_field(self):
+    def test_rating_change_generated_field(self) -> None:
         """``rating_change`` reflects ``rating - previous_rating``."""
         team = self._create_team("Change Team")
         rating = GlickoRating.objects.create(

--- a/tests/core/models/test_match_model.py
+++ b/tests/core/models/test_match_model.py
@@ -1,3 +1,5 @@
+"""Tests for the :class:`Match` model."""
+
 from datetime import datetime
 from datetime import timezone as dt_timezone
 
@@ -10,7 +12,10 @@ from core.models.team import Team
 
 
 class MatchModelTests(TestCase):
-    def setUp(self):
+    """Tests for ``Match`` model behavior."""
+
+    def setUp(self) -> None:
+        """Create two teams used in match tests."""
         self.home_team = Team.objects.create(
             school="Home Team",
             color="#ffffff",
@@ -23,7 +28,7 @@ class MatchModelTests(TestCase):
         )
         self.start = datetime(2023, 1, 1, 12, 0, tzinfo=dt_timezone.utc)
 
-    def test_incomplete_match_without_scores(self):
+    def test_incomplete_match_without_scores(self) -> None:
         """An incomplete match may omit scores."""
         match = Match.objects.create(
             season=2023,
@@ -37,7 +42,7 @@ class MatchModelTests(TestCase):
         self.assertIsNone(match.home_score)
         self.assertIsNone(match.away_score)
 
-    def test_completed_match_requires_scores(self):
+    def test_completed_match_requires_scores(self) -> None:
         """Completed matches must include scores."""
         with transaction.atomic(), self.assertRaises(IntegrityError):
             Match.objects.create(
@@ -51,7 +56,7 @@ class MatchModelTests(TestCase):
                 home_score=21,
             )
 
-    def test_str_returns_matchup_and_date(self):
+    def test_str_returns_matchup_and_date(self) -> None:
         """``__str__`` returns the matchup and start date."""
         match = Match.objects.create(
             season=2023,

--- a/tests/core/models/test_team_model.py
+++ b/tests/core/models/test_team_model.py
@@ -1,3 +1,5 @@
+"""Tests for custom :class:`Team` manager behaviors."""
+
 from django.db import connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
@@ -6,14 +8,16 @@ from core.models.team import Team, TeamAlternativeName, TeamLogo
 
 
 class TeamManagerTests(TestCase):
+    """Tests for the ``Team`` model manager and related properties."""
+
     def _create_team(
         self,
         school: str,
         logos: list[str],
         alt_names: list[str],
         mascot: str | None = "",
-    ):
-        """Helper to create a team with optional related objects."""
+    ) -> Team:
+        """Create a team with optional related objects."""
         team = Team.objects.create(
             school=school,
             color="#ffffff",
@@ -26,7 +30,7 @@ class TeamManagerTests(TestCase):
             TeamAlternativeName.objects.create(team=team, name=name)
         return team
 
-    def test_prefetch_related(self):
+    def test_prefetch_related(self) -> None:
         """The default manager should prefetch logos and alt names."""
         for idx in range(3):
             # Each team gets two logos and one alternative name
@@ -45,27 +49,27 @@ class TeamManagerTests(TestCase):
         # One query for teams, one for logos, and one for alt names
         self.assertEqual(len(ctx.captured_queries), 3)
 
-    def test_logo_bright(self):
+    def test_logo_bright(self) -> None:
         """``logo_bright`` returns the first logo URL."""
         team = self._create_team("Bright Team", ["url1", "url2"], [])
         self.assertEqual(team.logo_bright, "url1")
 
-    def test_logo_bright_none(self):
+    def test_logo_bright_none(self) -> None:
         """``logo_bright`` is ``None`` when no logos exist."""
         team = self._create_team("No Logo Team", [], [])
         self.assertIsNone(team.logo_bright)
 
-    def test_logo_dark(self):
+    def test_logo_dark(self) -> None:
         """``logo_dark`` returns the second logo URL."""
         team = self._create_team("Dark Team", ["url1", "url2", "url3"], [])
         self.assertEqual(team.logo_dark, "url2")
 
-    def test_logo_dark_none(self):
+    def test_logo_dark_none(self) -> None:
         """``logo_dark`` is ``None`` when fewer than two logos exist."""
         team = self._create_team("Single Logo Team", ["url1"], [])
         self.assertIsNone(team.logo_dark)
 
-    def test_with_related_manager_prefetches(self):
+    def test_with_related_manager_prefetches(self) -> None:
         """Calling ``with_related`` should prefetch related models."""
         for idx in range(3):
             self._create_team(
@@ -88,17 +92,17 @@ class TeamManagerTests(TestCase):
 
         self.assertEqual(len(ctx.captured_queries), 3)
 
-    def test_team_str_with_mascot(self):
+    def test_team_str_with_mascot(self) -> None:
         """``__str__`` should include the mascot when present."""
         team = self._create_team("Georgia", [], [], mascot="Bulldogs")
         self.assertEqual(str(team), "Georgia Bulldogs")
 
-    def test_team_str_without_mascot(self):
+    def test_team_str_without_mascot(self) -> None:
         """``__str__`` without a mascot returns just the school name."""
         team = self._create_team("Georgia Tech", [], [])
         self.assertEqual(str(team), "Georgia Tech")
 
-    def test_save_generates_unique_slugs(self):
+    def test_save_generates_unique_slugs(self) -> None:
         """Saving teams with the same school should increment slug suffix."""
         t1 = self._create_team("Slug School", [], [])
         t2 = self._create_team("Slug School", [], [])
@@ -108,7 +112,7 @@ class TeamManagerTests(TestCase):
         self.assertEqual(t2.slug, "slug-school-1")
         self.assertEqual(t3.slug, "slug-school-2")
 
-    def test_save_preserves_existing_slug(self):
+    def test_save_preserves_existing_slug(self) -> None:
         """Saving again shouldn't alter a valid, unique slug."""
         team = self._create_team("Persistent Slug", [], [])
 
@@ -118,13 +122,13 @@ class TeamManagerTests(TestCase):
         team.save()
         self.assertEqual(team.slug, original)
 
-    def test_team_alternative_name_str(self):
+    def test_team_alternative_name_str(self) -> None:
         """``TeamAlternativeName.__str__`` returns '<name> (<school>)'."""
         team = self._create_team("Name Team", [], ["Nickname"])
         alt = team.alternative_names.first()
         self.assertEqual(str(alt), "Nickname (Name Team)")
 
-    def test_team_logo_str(self):
+    def test_team_logo_str(self) -> None:
         """``TeamLogo.__str__`` includes the team school and URL."""
         team = self._create_team("Logo Team", ["http://logo"], [])
         logo = team.logos.first()

--- a/tests/core/models/test_venue_model.py
+++ b/tests/core/models/test_venue_model.py
@@ -1,17 +1,21 @@
+"""Tests for the :class:`Venue` model."""
+
 from django.test import TestCase
 
 from core.models.venue import Venue
 
 
 class VenueModelTests(TestCase):
-    def test_str_returns_name_and_location(self):
+    """Behavior tests for ``Venue``."""
+
+    def test_str_returns_name_and_location(self) -> None:
         """``__str__`` returns '<name> (<city>, <state>)'."""
         venue = Venue.objects.create(
             name="Memorial Stadium", city="Athens", state="GA"
         )
         self.assertEqual(str(venue), "Memorial Stadium (Athens, GA)")
 
-    def test_meta_options(self):
+    def test_meta_options(self) -> None:
         """Model meta options specify ordering and verbose names."""
         self.assertEqual(Venue._meta.ordering, ["name"])
         self.assertEqual(Venue._meta.verbose_name, "venue")

--- a/tests/core/views/__init__.py
+++ b/tests/core/views/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for view logic."""

--- a/tests/core/views/test_index_view.py
+++ b/tests/core/views/test_index_view.py
@@ -1,9 +1,13 @@
+"""Tests for the index view."""
+
 from django.test import TestCase
 from django.urls import reverse
 
 
 class IndexViewTests(TestCase):
-    def test_index_view_renders_template(self):
+    """Index view tests."""
+
+    def test_index_view_renders_template(self) -> None:
         """The index view should return the index template."""
         response = self.client.get(reverse("index"))
         self.assertEqual(response.status_code, 200)

--- a/tests/libs/__init__.py
+++ b/tests/libs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for shared libraries."""

--- a/tests/libs/test_glicko2.py
+++ b/tests/libs/test_glicko2.py
@@ -1,3 +1,5 @@
+"""Tests for the Glicko-2 rating algorithm implementation."""
+
 import math
 import os
 
@@ -12,7 +14,9 @@ django.setup()
 
 
 class Glicko2Test(TestCase):
-    def setUp(self):
+    """Tests for functions and helpers in :mod:`libs.glicko2`."""
+
+    def setUp(self) -> None:
         """Create a baseline player and deterministic match data."""
         self.player = Player(rating=1500, rd=200, vol=0.06, tau=0.5)
 
@@ -27,7 +31,7 @@ class Glicko2Test(TestCase):
         ]
         self.scaled_rds = [x / GLICKO2_SCALER for x in self.rd_list]
 
-    def test_pre_rating_rd(self):
+    def test_pre_rating_rd(self) -> None:
         """``_pre_rating_rd`` increases the rating deviation via volatility."""
         p = Player(rating=1500, rd=200, vol=0.06, tau=0.5)
         p._pre_rating_rd()
@@ -38,7 +42,7 @@ class Glicko2Test(TestCase):
         )
         self.assertAlmostEqual(p.rd, expected_rd, places=12)
 
-    def test_new_vol(self):
+    def test_new_vol(self) -> None:
         """``_new_vol`` returns the expected post-match volatility."""
         v = self.player._v(self.scaled_ratings, self.scaled_rds)
         new_vol = self.player._new_vol(
@@ -48,7 +52,7 @@ class Glicko2Test(TestCase):
         # Volatility converges to a known value for this match history
         self.assertAlmostEqual(new_vol, 0.05999342315486217)
 
-    def test_new_vol_if_branch(self):
+    def test_new_vol_if_branch(self) -> None:
         """``_new_vol`` handles large ``delta`` using the logarithmic case."""
         p = Player(rating=1500, rd=30, vol=0.06, tau=0.5)
         rating_list = [500]
@@ -67,15 +71,15 @@ class Glicko2Test(TestCase):
             0.06001325617796023,
         )
 
-    def test_new_vol_expands_bounds(self):
+    def test_new_vol_expands_bounds(self) -> None:
         """``_new_vol`` expands the search interval when ``f`` is negative."""
 
         class LoopPlayer(Player):
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 super().__init__(*args, **kwargs)
                 self._first = True
 
-            def _f(self, x, delta, v, a):
+            def _f(self, x: float, delta: float, v: float, a: float) -> float:
                 if self._first:
                     # Force the initial check negative so the loop executes
                     self._first = False
@@ -91,7 +95,7 @@ class Glicko2Test(TestCase):
         # Forcing the loop still converges to the known post-match volatility.
         self.assertAlmostEqual(new_vol, 0.05999342315486217, places=9)
 
-    def test_update_player(self):
+    def test_update_player(self) -> None:
         """``update_player`` applies rating, RD, and volatility updates."""
         self.player.update_player(
             self.rating_list, self.rd_list, self.outcome_list
@@ -102,7 +106,7 @@ class Glicko2Test(TestCase):
         self.assertAlmostEqual(self.player.rd, 151.51651409762084)
         self.assertAlmostEqual(self.player.vol, 0.05999342315486217)
 
-    def test_did_not_compete(self):
+    def test_did_not_compete(self) -> None:
         """``did_not_compete`` defers updates but increases the RD."""
         p = Player(rating=1500, rd=50, vol=0.06, tau=0.5)
         p.did_not_compete()


### PR DESCRIPTION
## Summary
- enable linting for tests by removing per-file ignores
- add missing docstrings and type annotations across test suite

## Testing
- `ruff check`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6898639a49c483299343a5cee21b2767