### PR TITLE
Handle empty rankings table

### DIFF
--- a/templates/cotton/ranking_table.html
+++ b/templates/cotton/ranking_table.html
@@ -46,6 +46,10 @@
                     <td>{{ rating.rating | floatformat:0 }}</td>
                     <td>{{ rating.rating_change | floatformat:0 }}</td>
                 </tr>
+            {% empty %}
+                <tr>
+                    <td colspan="4" class="text-center">No rankings available</td>
+                </tr>
             {% endfor %}
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- display placeholder when no ratings are available

## Testing
- `pre-commit run --files templates/cotton/ranking_table.html`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689876ccfe0c8329a4cf2e5080b4c220