### PR TITLE
Highlight active navbar links

### DIFF
--- a/templates/cotton/nav_link.html
+++ b/templates/cotton/nav_link.html
@@ -1,0 +1,41 @@
+{# Reusable nav link component applying 'active' class for current route #}
+{# Parameters:
+ - url_name: name of the URL pattern
+ - label: text to display
+ - classification: optional classification slug for rankings
+ - base_class: CSS class for <a>, defaults to 'nav-link'
+ - href: optional explicit href value
+ - extra_attrs: optional extra attributes to append to the tag
+#}
+{% if classification %}
+    {% url url_name classification as nav_url %}
+{% else %}
+    {% url url_name as nav_url %}
+{% endif %}
+{% if request.resolver_match.url_name == url_name %}
+    {% if classification %}
+        {% if request.resolver_match.kwargs.classification == classification %}
+            <a class="{{ base_class|default:'nav-link' }} active"
+               aria-current="page"
+               href="{% if href %}{{ href }}{% else %}{{ nav_url }}{% endif %}"{% if extra_attrs %} {{ extra_attrs|safe }}{% endif %}>
+                {{ label }}
+            </a>
+        {% else %}
+            <a class="{{ base_class|default:'nav-link' }}"
+               href="{% if href %}{{ href }}{% else %}{{ nav_url }}{% endif %}"{% if extra_attrs %} {{ extra_attrs|safe }}{% endif %}>
+                {{ label }}
+            </a>
+        {% endif %}
+    {% else %}
+        <a class="{{ base_class|default:'nav-link' }} active"
+           aria-current="page"
+           href="{% if href %}{{ href }}{% else %}{{ nav_url }}{% endif %}"{% if extra_attrs %} {{ extra_attrs|safe }}{% endif %}>
+            {{ label }}
+        </a>
+    {% endif %}
+{% else %}
+    <a class="{{ base_class|default:'nav-link' }}"
+       href="{% if href %}{{ href }}{% else %}{{ nav_url }}{% endif %}"{% if extra_attrs %} {{ extra_attrs|safe }}{% endif %}>
+        {{ label }}
+    </a>
+{% endif %}

--- a/templates/cotton/nav_link.html
+++ b/templates/cotton/nav_link.html
@@ -1,7 +1,6 @@
 {# Reusable nav link component applying 'active' class for current route #}
 {# Parameters:
  - url_name: name of the URL pattern
- - label: text to display
  - classification: optional classification slug for rankings
  - base_class: CSS class for <a>, defaults to 'nav-link'
  - href: optional explicit href value
@@ -18,24 +17,24 @@
             <a class="{{ base_class|default:'nav-link' }} active"
                aria-current="page"
                href="{% if href %}{{ href }}{% else %}{{ nav_url }}{% endif %}"{% if extra_attrs %} {{ extra_attrs|safe }}{% endif %}>
-                {{ label }}
+                {{ slot }}
             </a>
         {% else %}
             <a class="{{ base_class|default:'nav-link' }}"
                href="{% if href %}{{ href }}{% else %}{{ nav_url }}{% endif %}"{% if extra_attrs %} {{ extra_attrs|safe }}{% endif %}>
-                {{ label }}
+                {{ slot }}
             </a>
         {% endif %}
     {% else %}
         <a class="{{ base_class|default:'nav-link' }} active"
            aria-current="page"
            href="{% if href %}{{ href }}{% else %}{{ nav_url }}{% endif %}"{% if extra_attrs %} {{ extra_attrs|safe }}{% endif %}>
-            {{ label }}
+            {{ slot }}
         </a>
     {% endif %}
 {% else %}
     <a class="{{ base_class|default:'nav-link' }}"
        href="{% if href %}{{ href }}{% else %}{{ nav_url }}{% endif %}"{% if extra_attrs %} {{ extra_attrs|safe }}{% endif %}>
-        {{ label }}
+        {{ slot }}
     </a>
 {% endif %}

--- a/templates/cotton/navbar.html
+++ b/templates/cotton/navbar.html
@@ -18,22 +18,25 @@
         <div class="collapse navbar-collapse" id="navbar-menu">
             <ul class="navbar-nav me-auto mb-2 mb-md-0">
                 <li class="nav-item">
-                    {% include "cotton/nav_link.html" with url_name='index' label='Dashboard' %}
+                    <c-nav-link url_name="index">Dashboard</c-nav-link>
                 </li>
                 <li class="nav-item dropdown">
-                    {% include "cotton/nav_link.html" with url_name='rankings' label='Rankings' base_class='nav-link dropdown-toggle' href="#" extra_attrs='role="button" data-bs-toggle="dropdown" aria-expanded="false"' %}
+                    <c-nav-link url_name="rankings"
+                                 base_class="nav-link dropdown-toggle"
+                                 href="#"
+                                 extra_attrs="role='button' data-bs-toggle='dropdown' aria-expanded='false'">Rankings</c-nav-link>
                     <ul class="dropdown-menu dropdown-menu-end mt-md-2 rounded-top-0">
                         <li>
-                            {% include "cotton/nav_link.html" with url_name='rankings' classification='fbs' label='FBS' base_class='dropdown-item' %}
+                            <c-nav-link url_name="rankings" classification="fbs" base_class="dropdown-item">FBS</c-nav-link>
                         </li>
                         <li>
-                            {% include "cotton/nav_link.html" with url_name='rankings' classification='fcs' label='FCS' base_class='dropdown-item' %}
+                            <c-nav-link url_name="rankings" classification="fcs" base_class="dropdown-item">FCS</c-nav-link>
                         </li>
                         <li>
-                            {% include "cotton/nav_link.html" with url_name='rankings' classification='ii' label='Div. II' base_class='dropdown-item' %}
+                            <c-nav-link url_name="rankings" classification="ii" base_class="dropdown-item">Div. II</c-nav-link>
                         </li>
                         <li>
-                            {% include "cotton/nav_link.html" with url_name='rankings' classification='iii' label='Div. III' base_class='dropdown-item' %}
+                            <c-nav-link url_name="rankings" classification="iii" base_class="dropdown-item">Div. III</c-nav-link>
                         </li>
                     </ul>
                 </li>

--- a/templates/cotton/navbar.html
+++ b/templates/cotton/navbar.html
@@ -18,26 +18,22 @@
         <div class="collapse navbar-collapse" id="navbar-menu">
             <ul class="navbar-nav me-auto mb-2 mb-md-0">
                 <li class="nav-item">
-                    <a class="nav-link active" aria-current="page" href="{% url 'index' %}">Dashboard</a>
+                    {% include "cotton/nav_link.html" with url_name='index' label='Dashboard' %}
                 </li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle"
-                       href="#"
-                       role="button"
-                       data-bs-toggle="dropdown"
-                       aria-expanded="false">Rankings</a>
+                    {% include "cotton/nav_link.html" with url_name='rankings' label='Rankings' base_class='nav-link dropdown-toggle' href="#" extra_attrs='role="button" data-bs-toggle="dropdown" aria-expanded="false"' %}
                     <ul class="dropdown-menu dropdown-menu-end mt-md-2 rounded-top-0">
                         <li>
-                            <a class="dropdown-item" href="{% url 'rankings' 'fbs' %}">FBS</a>
+                            {% include "cotton/nav_link.html" with url_name='rankings' classification='fbs' label='FBS' base_class='dropdown-item' %}
                         </li>
                         <li>
-                            <a class="dropdown-item" href="{% url 'rankings' 'fcs' %}">FCS</a>
+                            {% include "cotton/nav_link.html" with url_name='rankings' classification='fcs' label='FCS' base_class='dropdown-item' %}
                         </li>
                         <li>
-                            <a class="dropdown-item" href="{% url 'rankings' 'ii' %}">Div. II</a>
+                            {% include "cotton/nav_link.html" with url_name='rankings' classification='ii' label='Div. II' base_class='dropdown-item' %}
                         </li>
                         <li>
-                            <a class="dropdown-item" href="{% url 'rankings' 'iii' %}">Div. III</a>
+                            {% include "cotton/nav_link.html" with url_name='rankings' classification='iii' label='Div. III' base_class='dropdown-item' %}
                         </li>
                     </ul>
                 </li>


### PR DESCRIPTION
## Summary
- Extract reusable nav link cotton component that marks links active based on current route
- Use the component in the navbar to highlight dashboard and ranking items

## Testing
- `pre-commit run --files templates/cotton/navbar.html templates/cotton/nav_link.html`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689874a6bf78832993e875ddfa3df397