### PR TITLE
Add Elo rating management command

### DIFF
--- a/core/management/commands/elo.py
+++ b/core/management/commands/elo.py
@@ -1,0 +1,94 @@
+"""Management command to calculate Elo ratings for matches."""
+
+from django.core.management.base import BaseCommand
+
+from core.models.elo import EloRating
+from core.models.match import Match
+from libs.constants import ELO_DEFAULT_RATING, ELO_K_FACTOR
+
+
+def _expected_score(rating_a: float, rating_b: float) -> float:
+    """Return expected score for ``rating_a`` against ``rating_b``."""
+    return 1 / (1 + 10 ** ((rating_b - rating_a) / 400))
+
+
+class Command(BaseCommand):
+    """Calculate Elo ratings for each team in each match."""
+
+    help = "Calculate Elo ratings for each team in each match"
+
+    k_factor = ELO_K_FACTOR
+
+    def handle(self, *args: str, **options: int | str | None) -> None:  # noqa: D401
+        """Run the Elo rating calculation."""
+        self.stdout.write("Clearing existing Elo ratings...")
+        EloRating.objects.all().delete()
+
+        self.stdout.write("Calculating Elo ratings...")
+        current_ratings: dict[int, float] = {}
+        rating_records: list[EloRating] = []
+
+        matches = Match.objects.filter(completed=True).order_by(
+            "season", "week", "start_date", "id"
+        )
+
+        for match in matches:
+            home_before = current_ratings.get(
+                match.home_team_id, ELO_DEFAULT_RATING
+            )
+            away_before = current_ratings.get(
+                match.away_team_id, ELO_DEFAULT_RATING
+            )
+
+            if (
+                match.home_score is None or match.away_score is None
+            ):  # pragma: no cover
+                # skip matches without scores
+                continue
+
+            if match.home_score > match.away_score:
+                home_actual, away_actual = 1.0, 0.0
+            elif match.home_score < match.away_score:
+                home_actual, away_actual = 0.0, 1.0
+            else:
+                home_actual = away_actual = 0.5
+
+            expected_home = _expected_score(home_before, away_before)
+            expected_away = _expected_score(away_before, home_before)
+
+            home_after = home_before + self.k_factor * (
+                home_actual - expected_home
+            )
+            away_after = away_before + self.k_factor * (
+                away_actual - expected_away
+            )
+
+            self.stdout.write(
+                f"{match.home_team.school}: "
+                f"{home_before:.2f} -> {home_after:.2f}, "
+                f"{match.away_team.school}: {away_before:.2f} -> "
+                f"{away_after:.2f}"
+            )
+
+            rating_records.append(
+                EloRating(
+                    team_id=match.home_team_id,
+                    match_id=match.id,
+                    rating_before=home_before,
+                    rating_after=home_after,
+                )
+            )
+            rating_records.append(
+                EloRating(
+                    team_id=match.away_team_id,
+                    match_id=match.id,
+                    rating_before=away_before,
+                    rating_after=away_after,
+                )
+            )
+
+            current_ratings[match.home_team_id] = home_after
+            current_ratings[match.away_team_id] = away_after
+
+        if rating_records:
+            EloRating.objects.bulk_create(rating_records, batch_size=500)

--- a/libs/constants.py
+++ b/libs/constants.py
@@ -1,4 +1,4 @@
-"""Constants for the Glicko-2 rating system."""
+"""Shared constants for the rating systems (Glicko-2, Elo)."""
 
 from core.models.enums import DivisionClassification
 
@@ -9,6 +9,10 @@ DEFAULT_VOLATILITY = 0.11
 GLICKO2_SCALER = 173.7178
 TAU = 0.9
 CONVERGENCE_TOLERANCE = 0.000001
+
+# Elo constants
+ELO_DEFAULT_RATING = 1500
+ELO_K_FACTOR = 32
 
 # Base ratings and rating deviations for each division
 DIVISION_BASE_RATINGS = {

--- a/tests/core/management/test_command_elo.py
+++ b/tests/core/management/test_command_elo.py
@@ -1,0 +1,134 @@
+"""Tests for the elo management command."""
+
+import io
+from importlib import import_module
+
+from django.test import TestCase
+from django.utils import timezone
+
+from core.models.elo import EloRating
+from core.models.enums import SeasonType
+from core.models.match import Match
+from core.models.team import Team
+
+Command = import_module("core.management.commands.elo").Command
+
+
+class EloCommandTests(TestCase):
+    """Behavior tests for the elo rating command."""
+
+    def setUp(self) -> None:
+        """Create a command instance with captured output."""
+        self.command = Command()
+        self.command.stdout = io.StringIO()
+        self.command.stderr = io.StringIO()
+
+    def _team(self, name: str) -> Team:
+        return Team.objects.create(
+            school=name,
+            color="#fff",
+            alternate_color="#000",
+        )
+
+    def _match(
+        self,
+        *,
+        season: int,
+        week: int,
+        home: Team,
+        away: Team,
+        home_score: int,
+        away_score: int,
+    ) -> Match:
+        return Match.objects.create(
+            season=season,
+            week=week,
+            season_type=SeasonType.REGULAR,
+            start_date=timezone.now(),
+            completed=True,
+            home_team=home,
+            away_team=away,
+            home_score=home_score,
+            away_score=away_score,
+        )
+
+    # handle ---------------------------------------------------------------
+    def test_handle_no_matches(self) -> None:
+        """Running ``handle`` with no data creates no ratings."""
+        self.command.handle()
+        self.assertEqual(EloRating.objects.count(), 0)
+
+    def test_handle_creates_ratings_per_match(self) -> None:
+        """``handle`` creates ratings and carries them across matches."""
+        a = self._team("A")
+        b = self._team("B")
+        self._match(
+            season=2024,
+            week=1,
+            home=a,
+            away=b,
+            home_score=20,
+            away_score=10,
+        )
+        self._match(
+            season=2024,
+            week=2,
+            home=b,
+            away=a,
+            home_score=30,
+            away_score=10,
+        )
+
+        self.command.handle()
+
+        self.assertEqual(EloRating.objects.count(), 4)
+
+        a_ratings = list(
+            EloRating.objects.filter(team=a).order_by("match__week")
+        )
+        self.assertAlmostEqual(a_ratings[0].rating_before, 1500)
+        self.assertAlmostEqual(a_ratings[0].rating_after, 1516, places=2)
+        self.assertAlmostEqual(a_ratings[1].rating_before, 1516, places=2)
+        self.assertAlmostEqual(a_ratings[1].rating_after, 1498.53, places=2)
+
+        output = self.command.stdout.getvalue()
+        self.assertIn(
+            "A: 1500.00 -> 1516.00, B: 1500.00 -> 1484.00",
+            output,
+        )
+        self.assertIn(
+            "B: 1484.00 -> 1501.47, A: 1516.00 -> 1498.53",
+            output,
+        )
+
+    def test_handle_away_win_and_tie(self) -> None:
+        """Away wins and ties are reflected in rating changes."""
+        a = self._team("A")
+        b = self._team("B")
+        # away team wins
+        self._match(
+            season=2024,
+            week=1,
+            home=a,
+            away=b,
+            home_score=10,
+            away_score=20,
+        )
+        # tie match
+        self._match(
+            season=2024,
+            week=2,
+            home=b,
+            away=a,
+            home_score=14,
+            away_score=14,
+        )
+
+        self.command.handle()
+
+        self.assertEqual(EloRating.objects.count(), 4)
+        b_ratings = list(
+            EloRating.objects.filter(team=b).order_by("match__week")
+        )
+        self.assertAlmostEqual(b_ratings[0].rating_after, 1516, places=2)
+        self.assertLess(b_ratings[1].rating_after, b_ratings[0].rating_after)


### PR DESCRIPTION
## Summary
- add `elo` management command to compute Elo ratings for every team per match
- move Elo constants to `libs/constants.py` and output per-match rating progress
- test Elo command across wins, losses, and ties

## Testing
- `pre-commit run --files libs/constants.py core/management/commands/elo.py tests/core/management/test_command_elo.py`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689920e2b71083299d3e0809f113610c