### PR TITLE
Add Elo home-field advantage

### DIFF
--- a/core/management/commands/elo.py
+++ b/core/management/commands/elo.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 
 from core.models.elo import EloRating
 from core.models.match import Match
-from libs.constants import ELO_DEFAULT_RATING, ELO_K_FACTOR
+from libs.constants import ELO_DEFAULT_RATING, ELO_HOME_ADVANTAGE, ELO_K_FACTOR
 
 
 def _expected_score(rating_a: float, rating_b: float) -> float:
@@ -53,8 +53,11 @@ class Command(BaseCommand):
             else:
                 home_actual = away_actual = 0.5
 
-            expected_home = _expected_score(home_before, away_before)
-            expected_away = _expected_score(away_before, home_before)
+            advantage = 0 if match.neutral_site else ELO_HOME_ADVANTAGE
+            expected_home = _expected_score(
+                home_before + advantage, away_before
+            )
+            expected_away = 1 - expected_home
 
             home_after = home_before + self.k_factor * (
                 home_actual - expected_home

--- a/libs/constants.py
+++ b/libs/constants.py
@@ -13,6 +13,7 @@ CONVERGENCE_TOLERANCE = 0.000001
 # Elo constants
 ELO_DEFAULT_RATING = 1500
 ELO_K_FACTOR = 32
+ELO_HOME_ADVANTAGE = 55
 
 # Base ratings and rating deviations for each division
 DIVISION_BASE_RATINGS = {

--- a/tests/core/management/test_command_elo.py
+++ b/tests/core/management/test_command_elo.py
@@ -10,8 +10,15 @@ from core.models.elo import EloRating
 from core.models.enums import SeasonType
 from core.models.match import Match
 from core.models.team import Team
+from libs.constants import (
+    ELO_DEFAULT_RATING,
+    ELO_HOME_ADVANTAGE,
+    ELO_K_FACTOR,
+)
 
-Command = import_module("core.management.commands.elo").Command
+elo_module = import_module("core.management.commands.elo")
+Command = elo_module.Command
+_expected_score = elo_module._expected_score
 
 
 class EloCommandTests(TestCase):
@@ -39,6 +46,7 @@ class EloCommandTests(TestCase):
         away: Team,
         home_score: int,
         away_score: int,
+        neutral_site: bool = False,
     ) -> Match:
         return Match.objects.create(
             season=season,
@@ -50,6 +58,7 @@ class EloCommandTests(TestCase):
             away_team=away,
             home_score=home_score,
             away_score=away_score,
+            neutral_site=neutral_site,
         )
 
     # handle ---------------------------------------------------------------
@@ -86,18 +95,39 @@ class EloCommandTests(TestCase):
         a_ratings = list(
             EloRating.objects.filter(team=a).order_by("match__week")
         )
-        self.assertAlmostEqual(a_ratings[0].rating_before, 1500)
-        self.assertAlmostEqual(a_ratings[0].rating_after, 1516, places=2)
-        self.assertAlmostEqual(a_ratings[1].rating_before, 1516, places=2)
-        self.assertAlmostEqual(a_ratings[1].rating_after, 1498.53, places=2)
+        self.assertAlmostEqual(a_ratings[0].rating_before, ELO_DEFAULT_RATING)
+
+        expected_a_home = _expected_score(
+            ELO_DEFAULT_RATING + ELO_HOME_ADVANTAGE, ELO_DEFAULT_RATING
+        )
+        a_after1 = ELO_DEFAULT_RATING + ELO_K_FACTOR * (1 - expected_a_home)
+        b_after1 = ELO_DEFAULT_RATING + ELO_K_FACTOR * (
+            0 - (1 - expected_a_home)
+        )
+
+        expected_b_home = _expected_score(
+            b_after1 + ELO_HOME_ADVANTAGE, a_after1
+        )
+        b_after2 = b_after1 + ELO_K_FACTOR * (1 - expected_b_home)
+        a_after2 = a_after1 + ELO_K_FACTOR * (0 - (1 - expected_b_home))
+
+        self.assertAlmostEqual(a_ratings[0].rating_after, a_after1, places=2)
+        self.assertAlmostEqual(a_ratings[1].rating_before, a_after1, places=2)
+        self.assertAlmostEqual(a_ratings[1].rating_after, a_after2, places=2)
 
         output = self.command.stdout.getvalue()
         self.assertIn(
-            "A: 1500.00 -> 1516.00, B: 1500.00 -> 1484.00",
+            (
+                f"A: {ELO_DEFAULT_RATING:.2f} -> {a_after1:.2f}, "
+                f"B: {ELO_DEFAULT_RATING:.2f} -> {b_after1:.2f}"
+            ),
             output,
         )
         self.assertIn(
-            "B: 1484.00 -> 1501.47, A: 1516.00 -> 1498.53",
+            (
+                f"B: {b_after1:.2f} -> {b_after2:.2f}, "
+                f"A: {a_after1:.2f} -> {a_after2:.2f}"
+            ),
             output,
         )
 
@@ -130,5 +160,76 @@ class EloCommandTests(TestCase):
         b_ratings = list(
             EloRating.objects.filter(team=b).order_by("match__week")
         )
-        self.assertAlmostEqual(b_ratings[0].rating_after, 1516, places=2)
+        expected_b_away = _expected_score(
+            ELO_DEFAULT_RATING, ELO_DEFAULT_RATING + ELO_HOME_ADVANTAGE
+        )
+        b_after = ELO_DEFAULT_RATING + ELO_K_FACTOR * (1 - expected_b_away)
+        self.assertAlmostEqual(b_ratings[0].rating_after, b_after, places=2)
         self.assertLess(b_ratings[1].rating_after, b_ratings[0].rating_after)
+
+    def test_home_vs_away_advantage(self) -> None:
+        """Away wins yield larger gains than home wins with equal ratings."""
+        a = self._team("A")
+        b = self._team("B")
+
+        # A wins at home
+        self._match(
+            season=2024,
+            week=1,
+            home=a,
+            away=b,
+            home_score=20,
+            away_score=10,
+        )
+        self.command.handle()
+        home_gain = (
+            EloRating.objects.get(team=a).rating_after - ELO_DEFAULT_RATING
+        )
+
+        Match.objects.all().delete()
+
+        # A wins away
+        self._match(
+            season=2024,
+            week=1,
+            home=b,
+            away=a,
+            home_score=10,
+            away_score=20,
+        )
+        # reinitialize command output
+        self.command = Command()
+        self.command.stdout = io.StringIO()
+        self.command.stderr = io.StringIO()
+        self.command.handle()
+        away_gain = (
+            EloRating.objects.get(team=a).rating_after - ELO_DEFAULT_RATING
+        )
+
+        self.assertGreater(away_gain, home_gain)
+
+    def test_neutral_site_no_home_advantage(self) -> None:
+        """Neutral site matches do not apply home-field advantage."""
+        a = self._team("A")
+        b = self._team("B")
+        self._match(
+            season=2024,
+            week=1,
+            home=a,
+            away=b,
+            home_score=20,
+            away_score=10,
+            neutral_site=True,
+        )
+
+        self.command.handle()
+
+        self.assertEqual(EloRating.objects.count(), 2)
+        home_rating = EloRating.objects.get(team=a)
+        away_rating = EloRating.objects.get(team=b)
+        expected = _expected_score(ELO_DEFAULT_RATING, ELO_DEFAULT_RATING)
+        home_after = ELO_DEFAULT_RATING + ELO_K_FACTOR * (1 - expected)
+        away_after = ELO_DEFAULT_RATING + ELO_K_FACTOR * (0 - (1 - expected))
+
+        self.assertAlmostEqual(home_rating.rating_after, home_after, places=2)
+        self.assertAlmostEqual(away_rating.rating_after, away_after, places=2)


### PR DESCRIPTION
## Summary
- add `ELO_HOME_ADVANTAGE` constant
- include home-field advantage in Elo expected score calculations
- skip home-field advantage for neutral-site games
- test home vs away outcomes and neutral-site matches with the advantage

## Testing
- `pre-commit run --files core/management/commands/elo.py tests/core/management/test_command_elo.py libs/constants.py`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6899da1e326483298d4753462d149a1f