### PR TITLE
Scale Elo rating by score differential

### DIFF
--- a/libs/constants.py
+++ b/libs/constants.py
@@ -14,6 +14,10 @@ CONVERGENCE_TOLERANCE = 0.000001
 ELO_DEFAULT_RATING = 1500
 ELO_K_FACTOR = 32
 ELO_HOME_ADVANTAGE = 55
+# Base for logarithmic score differential scaling in the Elo formula.
+# Rating change = K * log(diff + 1, ELO_SCORE_DIFFERENTIAL_BASE)
+#                 * (actual - expected)
+ELO_SCORE_DIFFERENTIAL_BASE = 10
 
 # Base ratings and rating deviations for each division
 DIVISION_BASE_RATINGS = {


### PR DESCRIPTION
## Summary
- scale Elo adjustments by logarithmic score differential
- document rating formula in constants and command
- test that bigger wins yield larger Elo gains

## Testing
- `pre-commit run --files libs/constants.py core/management/commands/elo.py tests/core/management/test_command_elo.py`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_689a09f236508329b5071d637ebf91fc