### PR TITLE
Add Elo helpers and tests

### DIFF
--- a/libs/elo.py
+++ b/libs/elo.py
@@ -1,0 +1,55 @@
+"""Elo rating helpers."""
+
+import math
+
+from .constants import (
+    ELO_HOME_ADVANTAGE,
+    ELO_K_FACTOR,
+    ELO_SCORE_DIFFERENTIAL_BASE,
+)
+
+
+def expected_score(rating_a: float, rating_b: float) -> float:
+    """Return the expected score for ``rating_a`` against ``rating_b``."""
+    return 1 / (1 + 10 ** ((rating_b - rating_a) / 400))
+
+
+def update_ratings(
+    home_rating: float,
+    away_rating: float,
+    home_score: int,
+    away_score: int,
+    *,
+    k_factor: float = ELO_K_FACTOR,
+    base: float = ELO_SCORE_DIFFERENTIAL_BASE,
+    home_advantage: float = ELO_HOME_ADVANTAGE,
+    neutral_site: bool = False,
+) -> tuple[float, float]:
+    """
+    Update and return the Elo ratings for a completed match.
+
+    ``home_rating`` and ``away_rating`` are the pre-match ratings.
+    ``home_score`` and ``away_score`` are the final scores.
+
+    The ``k_factor`` controls rating volatility. ``base`` adjusts how score
+    differential scales the rating change. ``home_advantage`` is added to the
+    home team's rating when the game is not at a neutral site.
+    """
+    if home_score > away_score:
+        home_actual, away_actual = 1.0, 0.0
+    elif home_score < away_score:
+        home_actual, away_actual = 0.0, 1.0
+    else:
+        home_actual = away_actual = 0.5
+
+    advantage = 0 if neutral_site else home_advantage
+    expected_home = expected_score(home_rating + advantage, away_rating)
+    expected_away = 1 - expected_home
+
+    score_diff = abs(home_score - away_score)
+    margin = math.log(score_diff + 1, base)
+
+    home_after = home_rating + k_factor * margin * (home_actual - expected_home)
+    away_after = away_rating + k_factor * margin * (away_actual - expected_away)
+
+    return home_after, away_after

--- a/tests/core/management/test_command_elo.py
+++ b/tests/core/management/test_command_elo.py
@@ -2,11 +2,11 @@
 
 import io
 import math
-from importlib import import_module
 
 from django.test import TestCase
 from django.utils import timezone
 
+from core.management.commands.elo import Command
 from core.models.elo import EloRating
 from core.models.enums import SeasonType
 from core.models.match import Match
@@ -17,10 +17,7 @@ from libs.constants import (
     ELO_K_FACTOR,
     ELO_SCORE_DIFFERENTIAL_BASE,
 )
-
-elo_module = import_module("core.management.commands.elo")
-Command = elo_module.Command
-_expected_score = elo_module._expected_score
+from libs.elo import expected_score
 
 
 class EloCommandTests(TestCase):
@@ -99,7 +96,7 @@ class EloCommandTests(TestCase):
         )
         self.assertAlmostEqual(a_ratings[0].rating_before, ELO_DEFAULT_RATING)
 
-        expected_a_home = _expected_score(
+        expected_a_home = expected_score(
             ELO_DEFAULT_RATING + ELO_HOME_ADVANTAGE, ELO_DEFAULT_RATING
         )
         margin1 = math.log(10 + 1, ELO_SCORE_DIFFERENTIAL_BASE)
@@ -110,7 +107,7 @@ class EloCommandTests(TestCase):
             0 - (1 - expected_a_home)
         )
 
-        expected_b_home = _expected_score(
+        expected_b_home = expected_score(
             b_after1 + ELO_HOME_ADVANTAGE, a_after1
         )
         margin2 = math.log(20 + 1, ELO_SCORE_DIFFERENTIAL_BASE)
@@ -168,7 +165,7 @@ class EloCommandTests(TestCase):
         b_ratings = list(
             EloRating.objects.filter(team=b).order_by("match__week")
         )
-        expected_b_away = _expected_score(
+        expected_b_away = expected_score(
             ELO_DEFAULT_RATING, ELO_DEFAULT_RATING + ELO_HOME_ADVANTAGE
         )
         margin = math.log(10 + 1, ELO_SCORE_DIFFERENTIAL_BASE)
@@ -279,7 +276,7 @@ class EloCommandTests(TestCase):
         self.assertEqual(EloRating.objects.count(), 2)
         home_rating = EloRating.objects.get(team=a)
         away_rating = EloRating.objects.get(team=b)
-        expected = _expected_score(ELO_DEFAULT_RATING, ELO_DEFAULT_RATING)
+        expected = expected_score(ELO_DEFAULT_RATING, ELO_DEFAULT_RATING)
         margin = math.log(10 + 1, ELO_SCORE_DIFFERENTIAL_BASE)
         home_after = ELO_DEFAULT_RATING + ELO_K_FACTOR * margin * (1 - expected)
         away_after = ELO_DEFAULT_RATING + ELO_K_FACTOR * margin * (

--- a/tests/libs/test_elo.py
+++ b/tests/libs/test_elo.py
@@ -1,0 +1,35 @@
+"""Tests for Elo rating helpers."""
+
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+import django
+from django.test import TestCase
+
+from libs.elo import expected_score, update_ratings
+
+django.setup()
+
+
+class EloHelpersTest(TestCase):
+    """Tests for functions in :mod:`libs.elo`."""
+
+    def test_expected_score(self) -> None:
+        """``expected_score`` returns probabilities based on rating gap."""
+        self.assertAlmostEqual(expected_score(1500, 1500), 0.5)
+        self.assertAlmostEqual(expected_score(1600, 1500), 0.6400649998028851)
+
+    def test_update_ratings_home_win(self) -> None:
+        """Home team gains points after a home victory."""
+        home_after, away_after = update_ratings(
+            1500, 1500, 21, 14, neutral_site=False
+        )
+        self.assertAlmostEqual(home_after, 1512.1809715981456)
+        self.assertAlmostEqual(away_after, 1487.8190284018544)
+
+    def test_update_ratings_draw_no_change(self) -> None:
+        """A draw does not adjust ratings when the margin is zero."""
+        home_after, away_after = update_ratings(1500, 1500, 21, 21)
+        self.assertEqual(home_after, 1500)
+        self.assertEqual(away_after, 1500)


### PR DESCRIPTION
## Summary
- extract Elo rating helpers into `libs/elo.py`
- refactor Elo management command to use shared helpers
- add unit tests for Elo helpers and update existing command tests

## Testing
- `pre-commit run --files libs/elo.py core/management/commands/elo.py tests/libs/test_elo.py tests/core/management/test_command_elo.py`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_689a16408f6c83298f85312d4631e4bc