### PR TITLE
Add Elo season reset options

### DIFF
--- a/libs/constants.py
+++ b/libs/constants.py
@@ -14,6 +14,7 @@ CONVERGENCE_TOLERANCE = 0.000001
 ELO_DEFAULT_RATING = 1500
 ELO_K_FACTOR = 32
 ELO_HOME_ADVANTAGE = 55
+ELO_DECAY_DEFAULT = 0.75  # Fraction of a rating retained between seasons
 # Base for logarithmic score differential scaling in the Elo formula.
 # Rating change = K * log(diff + 1, ELO_SCORE_DIFFERENTIAL_BASE)
 #                 * (actual - expected)

--- a/tests/core/management/test_command_elo.py
+++ b/tests/core/management/test_command_elo.py
@@ -14,6 +14,7 @@ from core.models.enums import SeasonType
 from core.models.match import Match
 from core.models.team import Team
 from libs.constants import (
+    ELO_DECAY_DEFAULT,
     ELO_DEFAULT_RATING,
     ELO_HOME_ADVANTAGE,
     ELO_K_FACTOR,
@@ -169,7 +170,10 @@ class EloCommandTests(TestCase):
         a_after, _ = update_ratings(
             ELO_DEFAULT_RATING, ELO_DEFAULT_RATING, 20, 10
         )
-        expected_start = (a_after + ELO_DEFAULT_RATING) / 2
+        expected_start = (
+            ELO_DEFAULT_RATING
+            + (a_after - ELO_DEFAULT_RATING) * ELO_DECAY_DEFAULT
+        )
         self.assertAlmostEqual(
             a_ratings[1].rating_before, expected_start, places=2
         )
@@ -248,6 +252,7 @@ class EloCommandTests(TestCase):
         self.command.add_arguments(parser)
         options = parser.parse_args([])
         self.assertTrue(hasattr(options, "decay"))
+        self.assertEqual(options.decay, ELO_DECAY_DEFAULT)
 
     def test_handle_invalid_decay_raises_error(self) -> None:
         """Invalid decay percentages raise ``CommandError``."""


### PR DESCRIPTION
## Summary
- adjust Elo ratings toward default at season boundaries with configurable decay
- drop the `--full-reset` flag; use `--decay 0` for a clean slate
- cover season transitions and option validation in tests

## Testing
- `./test.sh`
- `pre-commit run --files core/management/commands/elo.py tests/core/management/test_command_elo.py`


------
https://chatgpt.com/codex/tasks/task_e_689a1b17930483299c45121f15a8e179