### PR TITLE
Highlight active navbar link

### DIFF
--- a/templates/cotton/navbar.html
+++ b/templates/cotton/navbar.html
@@ -18,31 +18,31 @@
         <div class="collapse navbar-collapse" id="navbar-menu">
             <ul class="navbar-nav me-auto mb-2 mb-md-0">
                 <li class="nav-item">
-                    <a class="nav-link active" aria-current="page" href="{% url 'index' %}">Dashboard</a>
+                    <a class="nav-link {% if request.resolver_match.url_name == 'index' %}active{% endif %}" aria-current="page" href="{% url 'index' %}">Dashboard</a>
                 </li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle"
+                    <a class="nav-link dropdown-toggle {% if request.resolver_match.url_name == 'rankings' %}active{% endif %}"
                        href="#"
                        role="button"
                        data-bs-toggle="dropdown"
                        aria-expanded="false">Rankings</a>
                     <ul class="dropdown-menu dropdown-menu-end mt-md-2 rounded-top-0">
                         <li>
-                            <a class="dropdown-item" href="{% url 'rankings' 'fbs' %}">FBS</a>
+                            <a class="dropdown-item {% if request.resolver_match.kwargs.classification == 'fbs' %}active{% endif %}" href="{% url 'rankings' 'fbs' %}">FBS</a>
                         </li>
                         <li>
-                            <a class="dropdown-item" href="{% url 'rankings' 'fcs' %}">FCS</a>
+                            <a class="dropdown-item {% if request.resolver_match.kwargs.classification == 'fcs' %}active{% endif %}" href="{% url 'rankings' 'fcs' %}">FCS</a>
                         </li>
                         <li>
-                            <a class="dropdown-item" href="{% url 'rankings' 'ii' %}">Div. II</a>
+                            <a class="dropdown-item {% if request.resolver_match.kwargs.classification == 'ii' %}active{% endif %}" href="{% url 'rankings' 'ii' %}">Div. II</a>
                         </li>
                         <li>
-                            <a class="dropdown-item" href="{% url 'rankings' 'iii' %}">Div. III</a>
+                            <a class="dropdown-item {% if request.resolver_match.kwargs.classification == 'iii' %}active{% endif %}" href="{% url 'rankings' 'iii' %}">Div. III</a>
                         </li>
                     </ul>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="#">Contact</a>
+                    <a class="nav-link {% if request.resolver_match.url_name == 'contact' %}active{% endif %}" href="#">Contact</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- Dynamically mark navbar links as active by inspecting the current URL name and classification

## Testing
- `pre-commit run --files templates/cotton/navbar.html`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689a263a63108329bff89f4a216c55cc