### PR TITLE
Add dashboard summary cards

### DIFF
--- a/core/views/index_view.py
+++ b/core/views/index_view.py
@@ -2,8 +2,17 @@
 
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
+from django.utils import timezone
+
+from core.models.glicko import GlickoRating
+from core.models.match import Match
 
 
 def index_view(request: HttpRequest) -> HttpResponse:
-    """Render the index page."""
-    return render(request, "index.html")
+    """Render the index page with dashboard data."""
+    upcoming_games = Match.objects.filter(
+        start_date__gte=timezone.now()
+    ).order_by("start_date")[:5]
+    top_teams = GlickoRating.objects.filter(active=True).order_by("-rating")[:5]
+    context = {"upcoming_games": upcoming_games, "top_teams": top_teams}
+    return render(request, "index.html", context)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,30 @@
 {% extends "base.html" %}
 {% block content %}
-    <c-card title="Home">
-    {% lorem 4 p %}
-    </c-card>
+    <div class="row g-4">
+        <div class="col-md-6">
+            <c-card title="Upcoming Games">
+                <ul class="list-unstyled mb-0">
+                    {% for game in upcoming_games %}
+                        <li>
+                            {{ game.start_date|date:"M j, g:i a" }} -
+                            {{ game.away_team.name }} @ {{ game.home_team.name }}
+                        </li>
+                    {% empty %}
+                        <li>No upcoming games.</li>
+                    {% endfor %}
+                </ul>
+            </c-card>
+        </div>
+        <div class="col-md-6">
+            <c-card title="Top Teams">
+                <ol class="mb-0">
+                    {% for rating in top_teams %}
+                        <li>{{ rating.team.name }} ({{ rating.rating|floatformat:1 }})</li>
+                    {% empty %}
+                        <li>No ratings available.</li>
+                    {% endfor %}
+                </ol>
+            </c-card>
+        </div>
+    </div>
 {% endblock content %}


### PR DESCRIPTION
## Summary
- replace placeholder content on home page with cards listing upcoming games and top teams
- collect dashboard data in view for display

## Testing
- `pre-commit run --files templates/index.html core/views/index_view.py`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689a27ed31348329b4e7d760bf70500b