### PR TITLE
Add loading spinner indicator to ranking table

### DIFF
--- a/templates/cotton/ranking_table.html
+++ b/templates/cotton/ranking_table.html
@@ -1,10 +1,12 @@
 <div id="ranking-table">
+    <div id="loading-spinner" class="spinner-border d-none"></div>
     <form class="row mb-3"
           hx-get="{{ request.path }}"
           hx-trigger="change"
           hx-target="#ranking-table"
           hx-swap="outerHTML"
-          hx-replace-url="true">
+          hx-replace-url="true"
+          hx-indicator="#loading-spinner">
         <div class="col">
             <label for="season-select" class="form-label">Season</label>
             <select id="season-select" name="season" class="form-select rounded-0">


### PR DESCRIPTION
## Summary
- show a loading spinner during ranking table HTMX requests
- connect form with spinner via `hx-indicator`

## Testing
- `pre-commit run --files templates/cotton/ranking_table.html`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689a2deba224832999f86ba2f575511c