### PR TITLE
Prefetch team relations in ranking view

### DIFF
--- a/core/views/ranking_views.py
+++ b/core/views/ranking_views.py
@@ -89,7 +89,11 @@ class RankingListView(ListView):
     def get_queryset(self) -> QuerySet[GlickoRating]:
         """Return the filtered queryset for rankings."""
         classification = self.get_classification()
-        qs = GlickoRating.objects.all().select_related("team")
+        qs = (
+            GlickoRating.objects.all()
+            .select_related("team")
+            .prefetch_related("team__logos", "team__alternative_names")
+        )
 
         if classification:
             qs = qs.filter(classification=classification)


### PR DESCRIPTION
## Summary
- prefetch team logos and alternative names when fetching rankings

## Testing
- `python manage.py makemigrations`
- `pre-commit run --files core/views/ranking_views.py`
- `python manage.py test tests/core/views/test_ranking_views.py::RankingListViewTests::test_prefetch` *(fails: ModuleNotFoundError: No module named 'tests/core/views/test_ranking_views')*


------
https://chatgpt.com/codex/tasks/task_e_689a62cf5bc8832982303ad8a78c5118