### PR TITLE
Add team detail view with URL and tests

### DIFF
--- a/core/models/team.py
+++ b/core/models/team.py
@@ -1,6 +1,7 @@
 """Models for teams and related metadata."""
 
 from django.db import models
+from django.urls import reverse
 from django.utils.text import slugify
 
 from core.models.conference import Conference
@@ -102,6 +103,10 @@ class Team(models.Model):
                 counter += 1
             self.slug = slug
         super().save(*args, **kwargs)
+
+    def get_absolute_url(self) -> str:
+        """Return the URL for this team's detail page."""
+        return reverse("team-detail", args=[self.slug])
 
     @property
     def logo_bright(self) -> str | None:

--- a/core/urls.py
+++ b/core/urls.py
@@ -4,6 +4,7 @@ from django.urls import path
 
 from .views.index_view import index_view
 from .views.ranking_views import RankingListView
+from .views.team_views import TeamDetailView
 
 urlpatterns = [
     path("", index_view, name="index"),
@@ -11,5 +12,10 @@ urlpatterns = [
         "rankings/<str:classification>/",
         RankingListView.as_view(),
         name="rankings",
+    ),
+    path(
+        "teams/<slug:slug>/",
+        TeamDetailView.as_view(),
+        name="team-detail",
     ),
 ]

--- a/core/views/__init__.py
+++ b/core/views/__init__.py
@@ -1,7 +1,9 @@
 """Expose view classes for easy import."""
 
 from .ranking_views import RankingListView
+from .team_views import TeamDetailView
 
 __all__ = [
     "RankingListView",
+    "TeamDetailView",
 ]

--- a/core/views/team_views.py
+++ b/core/views/team_views.py
@@ -1,0 +1,16 @@
+"""Views related to team details."""
+
+from django.views.generic import DetailView
+
+from core.models.team import Team
+
+
+class TeamDetailView(DetailView):
+    """Display detailed information for a single team."""
+
+    model = Team
+    queryset = Team.objects.with_related()
+    context_object_name = "team"
+    template_name = "team_detail.html"
+    slug_field = "slug"
+    slug_url_kwarg = "slug"

--- a/templates/team_detail.html
+++ b/templates/team_detail.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+    <c-card title="{{ team }}">
+        {% if team.conference %}
+            <p>Conference: {{ team.conference }}</p>
+        {% endif %}
+        {% if team.classification %}
+            <p>Classification: {{ team.get_classification_display }}</p>
+        {% endif %}
+        {% if team.abbreviation %}
+            <p>Abbreviation: {{ team.abbreviation }}</p>
+        {% endif %}
+    </c-card>
+{% endblock content %}

--- a/tests/core/views/test_team_views.py
+++ b/tests/core/views/test_team_views.py
@@ -1,0 +1,50 @@
+"""Tests for team-related views."""
+
+from django.test import TestCase
+from django.urls import reverse
+
+from core.models.enums import DivisionClassification
+from core.models.glicko import GlickoRating
+from core.models.team import Team
+
+
+class TeamDetailViewTests(TestCase):
+    """Tests for the TeamDetailView and related links."""
+
+    def setUp(self) -> None:
+        """Create a team and rating for view tests."""
+        self.team = Team.objects.create(
+            school="Team A",
+            color="#000000",
+            alternate_color="#FFFFFF",
+            classification=DivisionClassification.FBS,
+        )
+        GlickoRating.objects.create(
+            team=self.team,
+            season=2024,
+            week=1,
+            classification=DivisionClassification.FBS,
+            rating=1500,
+            rd=30,
+            vol=0.06,
+        )
+        self.ranking_url = reverse(
+            "rankings", args=[DivisionClassification.FBS]
+        )
+
+    def test_team_detail_view_renders(self) -> None:
+        """The detail view should render with the team context."""
+        url = self.team.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "team_detail.html")
+        self.assertEqual(response.context["team"], self.team)
+
+    def test_link_from_ranking_table_resolves(self) -> None:
+        """Team links in ranking table should resolve to the detail view."""
+        response = self.client.get(self.ranking_url)
+        detail_url = self.team.get_absolute_url()
+        self.assertContains(response, f'href="{detail_url}"')
+        link_response = self.client.get(detail_url)
+        self.assertEqual(link_response.status_code, 200)
+        self.assertTemplateUsed(link_response, "team_detail.html")


### PR DESCRIPTION
## Summary
- add `TeamDetailView` and detail template
- expose team detail route and `Team.get_absolute_url`
- test team detail and ranking table links

## Testing
- `pre-commit run --files core/models/team.py core/urls.py core/views/__init__.py core/views/team_views.py templates/team_detail.html tests/core/views/test_team_views.py`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_689a631d4f4883298788e7e59988980f